### PR TITLE
Adding FP8-w8a8 MoE and optimize fp8 quantize func

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -117,7 +117,10 @@ import os
 
 SGLANG_DEEPSEEK_FP8A8 = os.getenv("SGLANG_DEEPSEEK_FP8A8", "0") == "1"
 SGLANG_LLAMA_BRGEMM_FP8A8 = os.getenv("SGLANG_LLAMA_BRGEMM_FP8A8", "0") == "1"
-
+SGLANG_BRGEMM_FUSED_FP8A8 = os.getenv("SGLANG_BRGEMM_FUSED_FP8A8", "0") == "1"
+if SGLANG_BRGEMM_FUSED_FP8A8:
+    SGLANG_LLAMA_BRGEMM_FP8A8 = True
+    SGLANG_DEEPSEEK_FP8A8  = True
 
 def _quantize_fp8e4m3(
     t: torch.Tensor, channelwise: bool, scale: Optional[torch.Tensor] = None
@@ -637,6 +640,16 @@ class Fp8LinearMethod(LinearMethodBase):
         if self.block_quant:
             if use_intel_amx_backend(layer):
                 if SGLANG_DEEPSEEK_FP8A8 and layer.use_f8f8:
+                    if SGLANG_BRGEMM_FUSED_FP8A8:
+                        return torch.ops.sgl_kernel.fp8_scaled_mm_with_quant(
+                            x,
+                            None,
+                            True,
+                            layer.weight,
+                            layer.weight_scale_inv,
+                            bias,
+                            x.dtype,
+                        )
                     x_q, x_s = _quantize_fp8e4m3(x, True)
                     # x_zp = torch.zeros_like(x_s).to(torch.int)
                     return torch.ops.sgl_kernel.float8_linear_cpu(
@@ -645,7 +658,7 @@ class Fp8LinearMethod(LinearMethodBase):
                         layer.weight,
                         layer.weight_scale_inv,
                         bias,
-                        torch.bfloat16,
+                        x.dtype,
                     )
                 else:
                     return torch.ops.sgl_kernel.fp8_scaled_mm_cpu(
@@ -667,7 +680,18 @@ class Fp8LinearMethod(LinearMethodBase):
                 bias=bias,
             )
         if self.quant_config.activation_scheme == "static":
-            q_input, scale = _quantize_fp8e4m3(x, False, layer.input_scale)
+            if not SGLANG_BRGEMM_FUSED_FP8A8:
+                q_input, scale = _quantize_fp8e4m3(x, False, layer.input_scale)
+            else:
+                return torch.ops.sgl_kernel.fp8_scaled_mm_with_quant(
+                    x,
+                    layer.input_scale,
+                    False,
+                    layer.weight,
+                    layer.weight_scale,
+                    bias,
+                    x.dtype,
+                )
 
             if SGLANG_LLAMA_BRGEMM_FP8A8:
                 return torch.ops.sgl_kernel.float8_linear_cpu(
@@ -954,7 +978,25 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 assert (
                     _is_cpu_amx_available
                 ), "Fp8MoEMethod on CPU requires that CPU has AMX support"
-                _amx_process_weight_after_loading(layer, ["w13_weight", "w2_weight"])
+                if not SGLANG_BRGEMM_FUSED_FP8A8:
+                    _amx_process_weight_after_loading(layer, ["w13_weight", "w2_weight"])
+                else:
+                    _amx_process_weight_after_loading(layer, ["w2_weight"])
+                    a8_w13_weight = []
+                    a8_w13_weight_scale = []
+                    w1 = layer.w13_weight
+                    w1s = layer.w13_weight_scale_inv 
+                    for i in range(layer.w13_weight.size(0)):
+                        new_w1s = torch.repeat_interleave(w1s[i], w1[i].size(0)//w1s[i].size(0), 0)
+                        new_w1s = new_w1s[: w1[i].size(0), :].contiguous()
+                        w1_a8, w1_a8_scale = torch.ops.sgl_kernel.float8_linear_prepack_cpu(
+                            w1[i], new_w1s
+                        )
+                        
+                        a8_w13_weight.append(w1_a8)
+                        a8_w13_weight_scale.append(w1_a8_scale)
+                    layer.w13_weight = torch.nn.Parameter(torch.stack(a8_w13_weight).detach(), requires_grad=False)
+                    layer.w13_weight_scale_inv = torch.nn.Parameter(torch.stack(a8_w13_weight_scale).detach(), requires_grad=False)
 
             return
 
@@ -1192,23 +1234,43 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             x, topk_weights = apply_topk_weights_cpu(
                 moe_runner_config.apply_router_weight_on_input, topk_weights, x
             )
-
-            output = torch.ops.sgl_kernel.fused_experts_cpu(
-                x,
-                layer.w13_weight,
-                layer.w2_weight,
-                topk_weights,
-                topk_ids,
-                False,  # inplace See [Note] inplace should be False in fused_experts.
-                False,  # use_int8_w8a8
-                True,  # use_fp8_w8a16
-                layer.w13_weight_scale_inv,  # w1_scale
-                layer.w2_weight_scale_inv,  # w2_scale
-                self.quant_config.weight_block_size,  # block_size
-                None,  # a1_scale
-                None,  # a2_scale
-                True,  # is_vnni
-            )
+            if not SGLANG_BRGEMM_FUSED_FP8A8:
+                output = torch.ops.sgl_kernel.fused_experts_cpu(
+                    x,
+                    layer.w13_weight,
+                    layer.w2_weight,
+                    topk_weights,
+                    topk_ids,
+                    False,  # inplace See [Note] inplace should be False in fused_experts.
+                    False,  # use_int8_w8a8
+                    True,  # use_fp8_w8a16
+                    False,
+                    layer.w13_weight_scale_inv,  # w1_scale
+                    layer.w2_weight_scale_inv,  # w2_scale
+                    self.quant_config.weight_block_size,  # block_size
+                    None,  # a1_scale
+                    None,  # a2_scale
+                    True,  # is_vnni
+                )
+            else:
+                x_q, x_s = torch.ops.sgl_kernel.quantize_fp8e4m3(x, True, None)
+                output = torch.ops.sgl_kernel.fused_experts_cpu(
+                    x_q,
+                    layer.w13_weight,
+                    layer.w2_weight,
+                    topk_weights,
+                    topk_ids,
+                    False,  # inplace See [Note] inplace should be False in fused_experts.
+                    False,  # use_int8_w8a8
+                    False,  # use_fp8_w8a16
+                    True,  # use_fp8_w8a8
+                    layer.w13_weight_scale_inv,  # w1_scale
+                    layer.w2_weight_scale_inv,  # w2_scale
+                    self.quant_config.weight_block_size,  # block_size
+                    x_s,  # a1_scale
+                    None,  # a2_scale
+                    True,  # is_vnni
+                )
             return StandardCombineInput(hidden_states=output)
 
         if _is_hip:

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -117,10 +117,10 @@ import os
 
 SGLANG_DEEPSEEK_FP8A8 = os.getenv("SGLANG_DEEPSEEK_FP8A8", "0") == "1"
 SGLANG_LLAMA_BRGEMM_FP8A8 = os.getenv("SGLANG_LLAMA_BRGEMM_FP8A8", "0") == "1"
-SGLANG_BRGEMM_FUSED_FP8A8 = os.getenv("SGLANG_BRGEMM_FUSED_FP8A8", "0") == "1"
-if SGLANG_BRGEMM_FUSED_FP8A8:
-    SGLANG_LLAMA_BRGEMM_FP8A8 = True
-    SGLANG_DEEPSEEK_FP8A8  = True
+SGLANG_BRGEMM_REF_FP8A8 = os.getenv("SGLANG_BRGEMM_REF_FP8A8", "0") == "1"
+if SGLANG_BRGEMM_REF_FP8A8:
+    SGLANG_LLAMA_BRGEMM_FP8A8 = False
+    SGLANG_DEEPSEEK_FP8A8  = False
 
 def _quantize_fp8e4m3(
     t: torch.Tensor, channelwise: bool, scale: Optional[torch.Tensor] = None
@@ -428,7 +428,7 @@ class Fp8LinearMethod(LinearMethodBase):
                 # _amx_process_weight_after_loading(layer, ["weight"])
                 layer.use_f8f8 = False
                 if (
-                    SGLANG_DEEPSEEK_FP8A8
+                    (SGLANG_DEEPSEEK_FP8A8 or SGLANG_BRGEMM_REF_FP8A8)
                     and not "shared_experts" in self.prefix
                     and not "qkv_a" in self.prefix
                     and not "q_b_proj" in self.prefix
@@ -465,7 +465,7 @@ class Fp8LinearMethod(LinearMethodBase):
             layer.weight_scale_inv.data = weight_scale.data
 
         elif (
-            SGLANG_LLAMA_BRGEMM_FP8A8
+            (SGLANG_LLAMA_BRGEMM_FP8A8 or SGLANG_BRGEMM_REF_FP8A8)
             and hasattr(self.quant_config, "activation_scheme")
             and self.quant_config.activation_scheme == "static"
         ):
@@ -640,18 +640,17 @@ class Fp8LinearMethod(LinearMethodBase):
         if self.block_quant:
             if use_intel_amx_backend(layer):
                 if SGLANG_DEEPSEEK_FP8A8 and layer.use_f8f8:
-                    if SGLANG_BRGEMM_FUSED_FP8A8:
-                        return torch.ops.sgl_kernel.fp8_scaled_mm_with_quant(
-                            x,
-                            None,
-                            True,
-                            layer.weight,
-                            layer.weight_scale_inv,
-                            bias,
-                            x.dtype,
-                        )
+                    return torch.ops.sgl_kernel.fp8_scaled_mm_with_quant(
+                        x,
+                        None,
+                        True,
+                        layer.weight,
+                        layer.weight_scale_inv,
+                        bias,
+                        x.dtype,
+                    )
+                elif SGLANG_BRGEMM_REF_FP8A8 and layer.use_f8f8:
                     x_q, x_s = _quantize_fp8e4m3(x, True)
-                    # x_zp = torch.zeros_like(x_s).to(torch.int)
                     return torch.ops.sgl_kernel.float8_linear_cpu(
                         x_q,
                         x_s,
@@ -680,9 +679,17 @@ class Fp8LinearMethod(LinearMethodBase):
                 bias=bias,
             )
         if self.quant_config.activation_scheme == "static":
-            if not SGLANG_BRGEMM_FUSED_FP8A8:
+            if SGLANG_BRGEMM_REF_FP8A8:
                 q_input, scale = _quantize_fp8e4m3(x, False, layer.input_scale)
-            else:
+                return torch.ops.sgl_kernel.float8_linear_cpu(
+                    q_input,
+                    scale,
+                    layer.weight,
+                    layer.weight_scale,
+                    bias,
+                    x.dtype,
+                )
+            elif SGLANG_LLAMA_BRGEMM_FP8A8:
                 return torch.ops.sgl_kernel.fp8_scaled_mm_with_quant(
                     x,
                     layer.input_scale,
@@ -692,24 +699,15 @@ class Fp8LinearMethod(LinearMethodBase):
                     bias,
                     x.dtype,
                 )
-
-            if SGLANG_LLAMA_BRGEMM_FP8A8:
-                return torch.ops.sgl_kernel.float8_linear_cpu(
+            else:
+                return torch._scaled_mm(
                     q_input,
-                    scale,
                     layer.weight,
-                    layer.weight_scale,
-                    bias,
-                    x.dtype,
+                    bias=bias,
+                    out_dtype=x.dtype,
+                    scale_a=layer.input_scale,
+                    scale_b=layer.weight_scale,
                 )
-            return torch._scaled_mm(
-                q_input,
-                layer.weight,
-                bias=bias,
-                out_dtype=x.dtype,
-                scale_a=layer.input_scale,
-                scale_b=layer.weight_scale,
-            )
 
         return apply_fp8_linear(
             input=x,
@@ -978,7 +976,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 assert (
                     _is_cpu_amx_available
                 ), "Fp8MoEMethod on CPU requires that CPU has AMX support"
-                if not SGLANG_BRGEMM_FUSED_FP8A8:
+                if not SGLANG_DEEPSEEK_FP8A8:
                     _amx_process_weight_after_loading(layer, ["w13_weight", "w2_weight"])
                 else:
                     _amx_process_weight_after_loading(layer, ["w2_weight"])
@@ -1234,7 +1232,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             x, topk_weights = apply_topk_weights_cpu(
                 moe_runner_config.apply_router_weight_on_input, topk_weights, x
             )
-            if not SGLANG_BRGEMM_FUSED_FP8A8:
+            if not SGLANG_DEEPSEEK_FP8A8:
                 output = torch.ops.sgl_kernel.fused_experts_cpu(
                     x,
                     layer.w13_weight,
@@ -1244,7 +1242,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                     False,  # inplace See [Note] inplace should be False in fused_experts.
                     False,  # use_int8_w8a8
                     True,  # use_fp8_w8a16
-                    False,
+                    False,  # use_fp8_w8a8
                     layer.w13_weight_scale_inv,  # w1_scale
                     layer.w2_weight_scale_inv,  # w2_scale
                     self.quant_config.weight_block_size,  # block_size

--- a/python/sglang/srt/layers/quantization/unquant.py
+++ b/python/sglang/srt/layers/quantization/unquant.py
@@ -335,6 +335,7 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, CustomOp):
                 False,  # inplace # See [Note] inplace should be False in fused_experts.
                 False,  # use_int8_w8a8
                 False,  # use_fp8_w8a16
+                False,  # use_fp8_w8a8
                 None,  # w1_scale
                 None,  # w2_scale
                 None,  # block_size

--- a/python/sglang/srt/layers/quantization/w8a8_int8.py
+++ b/python/sglang/srt/layers/quantization/w8a8_int8.py
@@ -543,6 +543,7 @@ class W8A8Int8MoEMethod(FusedMoEMethodBase):
                 False,  # inplace See [Note] inplace should be False in fused_experts.
                 True,  # use_int8_w8a8
                 False,  # use_fp8_w8a16
+                False,  # use_fp8_w8a8
                 layer.w13_weight_scale,  # w1_scale
                 layer.w2_weight_scale,  # w2_scale
                 None,  # block_size

--- a/sgl-kernel/csrc/cpu/gemm.h
+++ b/sgl-kernel/csrc/cpu/gemm.h
@@ -122,6 +122,7 @@ void fused_experts_fp8_a8_kernel_impl(
     at::Float8_e4m3fn* __restrict__ A_tmp,
     scalar_t* __restrict__ B_tmp,
     float* __restrict__ C_tmp,
+    float* __restrict__ Ukernel_tmp,
     const at::Float8_e4m3fn* __restrict__ input,
     const at::Float8_e4m3fn* __restrict__ packed_w1,
     const at::Float8_e4m3fn* __restrict__ packed_w2,
@@ -229,8 +230,7 @@ void tinygemm_kernel(
     int64_t block_size_K,
     bool do_unpack = true);
 
-// template <bool cpublas_can_pack, int64_t N, int act_quant_mode, int wei_quant_mode>
-void tinygemm_kernel2(
+void tinygemm_kernel(
     float* C,
     const at::Float8_e4m3fn* A,
     const float* scales_a,

--- a/sgl-kernel/csrc/cpu/gemm.h
+++ b/sgl-kernel/csrc/cpu/gemm.h
@@ -229,7 +229,7 @@ void tinygemm_kernel(
     int64_t block_size_K,
     bool do_unpack = true);
 
-template <bool cpublas_can_pack, int64_t N, int act_quant_mode, int wei_quant_mode>
+// template <bool cpublas_can_pack, int64_t N, int act_quant_mode, int wei_quant_mode>
 void tinygemm_kernel2(
     float* C,
     const at::Float8_e4m3fn* A,

--- a/sgl-kernel/csrc/cpu/gemm.h
+++ b/sgl-kernel/csrc/cpu/gemm.h
@@ -113,6 +113,34 @@ void fused_experts_fp8_kernel_impl(
     int64_t topk,
     int64_t num_tokens_post_pad);
 
+template <typename scalar_t>
+void fused_experts_fp8_a8_kernel_impl(
+    scalar_t* __restrict__ output,
+    scalar_t* __restrict__ ic0,
+    scalar_t* __restrict__ ic1,
+    scalar_t* __restrict__ ic2,
+    at::Float8_e4m3fn* __restrict__ A_tmp,
+    scalar_t* __restrict__ B_tmp,
+    float* __restrict__ C_tmp,
+    const at::Float8_e4m3fn* __restrict__ input,
+    const at::Float8_e4m3fn* __restrict__ packed_w1,
+    const at::Float8_e4m3fn* __restrict__ packed_w2,
+    const float* __restrict__ As,
+    const float* __restrict__ w1s,
+    const float* __restrict__ w2s,
+    int64_t block_size_N,
+    int64_t block_size_K,
+    const float* __restrict__ topk_weights,
+    const int32_t* __restrict__ sorted_ids,
+    const int32_t* __restrict__ expert_ids,
+    const int32_t* __restrict__ offsets,
+    int64_t M,
+    int64_t N,
+    int64_t K,
+    int64_t E,
+    int64_t topk,
+    int64_t num_tokens_post_pad);
+
 // shared expert implementation for int8 w8a8
 template <typename scalar_t>
 void shared_expert_int8_kernel_impl(
@@ -200,3 +228,19 @@ void tinygemm_kernel(
     bool brg,
     int64_t block_size_K,
     bool do_unpack = true);
+
+template <bool cpublas_can_pack, int64_t N, int act_quant_mode, int wei_quant_mode>
+void tinygemm_kernel2(
+    float* C,
+    const at::Float8_e4m3fn* A,
+    const float* scales_a,
+    const at::Float8_e4m3fn* B,
+    const float* scales_b,
+    int64_t M,
+    int64_t K,
+    int64_t lda,
+    int64_t ldc,
+    int64_t ldsa,
+    float* ukernel_buf,
+    at::BFloat16* dqA_buf,
+    at::BFloat16* dqB_buf);

--- a/sgl-kernel/csrc/cpu/gemm_fp8_w8a8.cpp
+++ b/sgl-kernel/csrc/cpu/gemm_fp8_w8a8.cpp
@@ -406,9 +406,7 @@ void _float8_linear_impl(
 
 }  // anonymous namespace
 
-
-// template <bool cpublas_can_pack, int64_t N, int act_quant_mode, int wei_quant_mode>
-void tinygemm_kernel2(
+void tinygemm_kernel(
     float* C,
     const at::Float8_e4m3fn* A,
     const float* scales_a,
@@ -422,25 +420,25 @@ void tinygemm_kernel2(
     float* ukernel_buf,
     at::BFloat16* dqA_buf,
     at::BFloat16* dqB_buf) {
-    // const N = block_n
-     _micro_gemm<true, BLOCK_N, 2, 3>(C, A, scales_a, B, scales_b, M, K, lda, ldc, ldsa, ukernel_buf,dqA_buf, dqB_buf );
-    }
+  // cpublas_can_pack = True, act_quant_mode = per row (2), wei_quant_mode = per group (3)
+  _micro_gemm<true, BLOCK_N, 2, 3>(C, A, scales_a, B, scales_b, M, K, lda, ldc, ldsa, ukernel_buf, dqA_buf, dqB_buf);
+}
 
-#define INSTANTIATE_TINYGEMM_TEMPLATE()    \
- void tinygemm_kernel2(         \
-    float* C, \
-    const at::Float8_e4m3fn* A,\
-    const float* scales_a,\
-    const at::Float8_e4m3fn* B,\
-    const float* scales_b,\
-    int64_t M,\
-    int64_t K,\
-    int64_t lda,\
-    int64_t ldc,\
-    int64_t ldsa,\
-    float* ukernel_buf,\
-    at::BFloat16* dqA_buf,\
-    at::BFloat16* dqB_buf)
+#define INSTANTIATE_TINYGEMM_TEMPLATE() \
+  void tinygemm_kernel(                 \
+      float* C,                         \
+      const at::Float8_e4m3fn* A,       \
+      const float* scales_a,            \
+      const at::Float8_e4m3fn* B,       \
+      const float* scales_b,            \
+      int64_t M,                        \
+      int64_t K,                        \
+      int64_t lda,                      \
+      int64_t ldc,                      \
+      int64_t ldsa,                     \
+      float* ukernel_buf,               \
+      at::BFloat16* dqA_buf,            \
+      at::BFloat16* dqB_buf)
 
 INSTANTIATE_TINYGEMM_TEMPLATE();
 /*
@@ -521,335 +519,195 @@ std::tuple<at::Tensor, at::Tensor> float8_linear_prepack_impl(const at::Tensor& 
   return std::make_tuple(std::move(blocked_weight), std::move(blocked_scales));
 }
 
-// Helper function for AVX512 scaling and clamping (FP32 -> FP32, then ATen converts to FP8)
-inline void scale_clamp_block_avx512(
-  const float* src, float* dst, int64_t size, float scale_reciprocal, float quant_max, float neg_quant_max) {
-  if (size <= 0) return;
-  
-  const __m512 scale_recip_vec = _mm512_set1_ps(scale_reciprocal);
-  const __m512 quant_max_vec = _mm512_set1_ps(quant_max);
-  const __m512 neg_quant_max_vec = _mm512_set1_ps(neg_quant_max);
-  
-  int64_t i = 0;
-  // Process 16 elements at a time (AVX512 width)
-  for (; i <= size - 16; i += 16) {
-      __m512 src_vec = _mm512_loadu_ps(&src[i]);
-      __m512 scaled_vec = _mm512_mul_ps(src_vec, scale_recip_vec);
-      __m512 clamped_vec = _mm512_min_ps(_mm512_max_ps(scaled_vec, neg_quant_max_vec), quant_max_vec);
-      _mm512_storeu_ps(&dst[i], clamped_vec);
-  }
-  
-  // Handle remaining elements
-  for (; i < size; ++i) {
-      float scaled = src[i] * scale_reciprocal;
-      dst[i] = std::clamp(scaled, neg_quant_max, quant_max);
-  }
-}
-
-std::tuple<at::Tensor, at::Tensor> _quantize_fp8e4m3_(
-  const at::Tensor& t,
-  bool channelwise,
-  c10::optional<at::Tensor> scale_opt = c10::nullopt
-) {
-  constexpr float quant_max = 448.0f; // torch.finfo(torch.float8_e4m3fn).max
-  constexpr float eps = std::numeric_limits<float>::epsilon();
-  
-  // Ensure input is contiguous and in float32 for processing
-  auto t_float = t.to(at::ScalarType::Float).contiguous();
-  at::Tensor qt;
-  at::Tensor scale_tensor;
-  
-  if (channelwise) {
-      if (!scale_opt.has_value()) {
-          // Compute scale per channel using parallel processing
-          int64_t num_channels = t_float.size(0);
-          scale_tensor = at::empty({num_channels}, t_float.options());
-          
-          at::parallel_for(0, num_channels, 1, [&](int64_t start, int64_t end) {
-              for (int64_t c = start; c < end; ++c) {
-                  auto channel_view = t_float.select(0, c);
-                  float channel_max = channel_view.abs().max().item<float>();
-                  scale_tensor[c] = std::max(channel_max / quant_max, eps);
-              }
-          });
-      } else {
-          scale_tensor = scale_opt.value().to(at::ScalarType::Float);
-          auto eps_tensor = at::full_like(scale_tensor, eps);
-          scale_tensor = at::where(scale_tensor > eps_tensor, scale_tensor, eps_tensor);
-      }
-      
-      // Reshape scale for broadcasting
-      std::vector<int64_t> scale_shape(t_float.dim(), 1);
-      scale_shape[0] = scale_tensor.size(0);
-      auto scale_reshaped = scale_tensor.reshape(scale_shape);
-      
-      // Quantize using vectorized division
-      qt = t_float / scale_reshaped;
-  } else {
-      if (!scale_opt.has_value()) {
-          // Compute global scale using vectorized max
-          float abs_max = t_float.abs().max().item<float>();
-          scale_tensor = at::tensor({std::max(abs_max / quant_max, eps)}, 
-                                   t_float.options().device(t_float.device()));
-          
-          // Vectorized quantization
-          qt = t_float / scale_tensor.item<float>();
-      } else {
-          scale_tensor = scale_opt.value().to(at::ScalarType::Float);
-          float scale_val;
-          
-          if (scale_tensor.numel() == 1) {
-              // Handle scalar tensor case
-              if (scale_tensor.scalar_type() == at::ScalarType::Float) {
-                  scale_val = std::max(scale_tensor.item<float>(), eps);
-              } else if (scale_tensor.scalar_type() == at::ScalarType::Double) {
-                  scale_val = std::max(scale_tensor.item<double>(), static_cast<double>(eps));
-              } else {
-                  scale_val = std::max(scale_tensor.item<float>(), eps);
-              }
-          } else {
-              // Handle tensor case - take max of all elements
-              float tensor_max = scale_tensor.max().item<float>();
-              scale_val = std::max(tensor_max, eps);
-          }
-          
-          scale_tensor = at::tensor({scale_val}, scale_tensor.options());
-          float scale_reciprocal = 1.0f / scale_val;
-          
-          // Create output tensor for quantized values
-          qt = at::empty_like(t_float);
-          
-          if (t_float.is_contiguous() && t_float.numel() >= 64 ) {
-              // AVX512 optimized path for scaling and clamping
-              at::parallel_for(0, t_float.numel(), 4096, [&](int64_t start, int64_t end) {
-                  int64_t block_size = end - start;
-                  scale_clamp_block_avx512(
-                      t_float.data_ptr<float>() + start,
-                      qt.data_ptr<float>() + start,
-                      block_size,
-                      scale_reciprocal,
-                      quant_max,
-                      -quant_max
-                  );
-              });
-          } else {
-              // Scale the tensor
-              qt = at::div(t_float, scale_val);
-              // Clamp to FP8 range
-              qt = at::clamp(qt, -quant_max, quant_max);
-          }
-      }
-  }
-  
-  // Final conversion to FP8 E4M3FN using ATen's native conversion
-  qt = at::_to_copy(qt, at::ScalarType::Float8_e4m3fn);
-  return std::make_tuple(qt, scale_tensor);
-}
-
-
 // AVX512 optimized channel-wise max computation
-inline void compute_channel_max_avx512(
-  const float* data, float* max_vals, int64_t num_channels, int64_t elements_per_channel) {
+inline void
+compute_channel_max_avx512(const float* data, float* max_vals, int64_t num_channels, int64_t elements_per_channel) {
   at::parallel_for(0, num_channels, 1, [&](int64_t start, int64_t end) {
-      for (int64_t c = start; c < end; ++c) {
-          const float* channel_data = data + c * elements_per_channel;
-          float max_val = 0.0f;
-          
-          int64_t i = 0;
-          // Process 16 elements at a time
-          __m512 max_vec = _mm512_setzero_ps();
-          
-          for (; i <= elements_per_channel - 16; i += 16) {
-              __m512 data_vec = _mm512_loadu_ps(&channel_data[i]);
-              __m512 abs_vec = _mm512_abs_ps(data_vec);
-              max_vec = _mm512_max_ps(max_vec, abs_vec);
-          }
-          
-          // Horizontal max of the vector
-          float hmax = _mm512_reduce_max_ps(max_vec);
-          max_val = std::max(max_val, hmax);
-          
-          // Handle remaining elements
-          for (; i < elements_per_channel; ++i) {
-              max_val = std::max(max_val, std::abs(channel_data[i]));
-          }
-          
-          max_vals[c] = max_val;
+    for (int64_t c = start; c < end; ++c) {
+      const float* channel_data = data + c * elements_per_channel;
+      float max_val = 0.0f;
+
+      int64_t i = 0;
+      // Process 16 elements at a time
+      __m512 max_vec = _mm512_setzero_ps();
+
+      for (; i <= elements_per_channel - 16; i += 16) {
+        __m512 data_vec = _mm512_loadu_ps(&channel_data[i]);
+        __m512 abs_vec = _mm512_abs_ps(data_vec);
+        max_vec = _mm512_max_ps(max_vec, abs_vec);
       }
+
+      // Horizontal max of the vector
+      float hmax = _mm512_reduce_max_ps(max_vec);
+      max_val = std::max(max_val, hmax);
+
+      // Handle remaining elements
+      for (; i < elements_per_channel; ++i) {
+        max_val = std::max(max_val, std::abs(channel_data[i]));
+      }
+
+      max_vals[c] = max_val;
+    }
   });
 }
 
 // AVX512 optimized scaling and clamping for channel-wise quantization
 inline void scale_clamp_channelwise_avx512(
-  const float* src, float* dst, const float* scales, 
-  int64_t num_channels, int64_t elements_per_channel, 
-  float quant_max, float neg_quant_max) {
-  
+    const float* src,
+    float* dst,
+    const float* scales,
+    int64_t num_channels,
+    int64_t elements_per_channel,
+    float quant_max,
+    float neg_quant_max) {
   at::parallel_for(0, num_channels, 1, [&](int64_t start, int64_t end) {
-      for (int64_t c = start; c < end; ++c) {
-          float scale_val = scales[c];
-          float scale_reciprocal = 1.0f / scale_val;
-          
-          const float* channel_src = src + c * elements_per_channel;
-          float* channel_dst = dst + c * elements_per_channel;
-          
-          int64_t i = 0;
-          const __m512 scale_recip_vec = _mm512_set1_ps(scale_reciprocal);
-          const __m512 quant_max_vec = _mm512_set1_ps(quant_max);
-          const __m512 neg_quant_max_vec = _mm512_set1_ps(neg_quant_max);
-          
-          for (; i <= elements_per_channel - 16; i += 16) {
-              __m512 src_vec = _mm512_loadu_ps(&channel_src[i]);
-              __m512 scaled_vec = _mm512_mul_ps(src_vec, scale_recip_vec);
-              __m512 clamped_vec = _mm512_min_ps(_mm512_max_ps(scaled_vec, neg_quant_max_vec), quant_max_vec);
-              _mm512_storeu_ps(&channel_dst[i], clamped_vec);
-          }
-          
-          // Handle remaining elements
-          for (; i < elements_per_channel; ++i) {
-              float scaled = channel_src[i] * scale_reciprocal;
-              channel_dst[i] = std::clamp(scaled, neg_quant_max, quant_max);
-          }
+    for (int64_t c = start; c < end; ++c) {
+      float scale_val = scales[c];
+      float scale_reciprocal = 1.0f / scale_val;
+
+      const float* channel_src = src + c * elements_per_channel;
+      float* channel_dst = dst + c * elements_per_channel;
+
+      int64_t i = 0;
+      const __m512 scale_recip_vec = _mm512_set1_ps(scale_reciprocal);
+      const __m512 quant_max_vec = _mm512_set1_ps(quant_max);
+      const __m512 neg_quant_max_vec = _mm512_set1_ps(neg_quant_max);
+
+      for (; i <= elements_per_channel - 16; i += 16) {
+        __m512 src_vec = _mm512_loadu_ps(&channel_src[i]);
+        __m512 scaled_vec = _mm512_mul_ps(src_vec, scale_recip_vec);
+        __m512 clamped_vec = _mm512_min_ps(_mm512_max_ps(scaled_vec, neg_quant_max_vec), quant_max_vec);
+        _mm512_storeu_ps(&channel_dst[i], clamped_vec);
       }
+
+      // Handle remaining elements
+      for (; i < elements_per_channel; ++i) {
+        float scaled = channel_src[i] * scale_reciprocal;
+        channel_dst[i] = std::clamp(scaled, neg_quant_max, quant_max);
+      }
+    }
   });
 }
 
 // AVX512 optimized scaling and clamping for global quantization
 inline void scale_clamp_global_avx512(
-  const float* src, float* dst, int64_t size, 
-  float scale_reciprocal, float quant_max, float neg_quant_max) {
-  
+    const float* src, float* dst, int64_t size, float scale_reciprocal, float quant_max, float neg_quant_max) {
   if (size <= 0) return;
-  
+
   const __m512 scale_recip_vec = _mm512_set1_ps(scale_reciprocal);
   const __m512 quant_max_vec = _mm512_set1_ps(quant_max);
   const __m512 neg_quant_max_vec = _mm512_set1_ps(neg_quant_max);
-  
+
   at::parallel_for(0, size, 4096, [&](int64_t start, int64_t end) {
-      int64_t block_size = end - start;
-      const float* block_src = src + start;
-      float* block_dst = dst + start;
-      
-      int64_t i = 0;
-      for (; i <= block_size - 16; i += 16) {
-          __m512 src_vec = _mm512_loadu_ps(&block_src[i]);
-          __m512 scaled_vec = _mm512_mul_ps(src_vec, scale_recip_vec);
-          __m512 clamped_vec = _mm512_min_ps(_mm512_max_ps(scaled_vec, neg_quant_max_vec), quant_max_vec);
-          _mm512_storeu_ps(&block_dst[i], clamped_vec);
-      }
-      
-      // Handle remaining elements in block
-      for (; i < block_size; ++i) {
-          float scaled = block_src[i] * scale_reciprocal;
-          block_dst[i] = std::clamp(scaled, neg_quant_max, quant_max);
-      }
+    int64_t block_size = end - start;
+    const float* block_src = src + start;
+    float* block_dst = dst + start;
+
+    int64_t i = 0;
+    for (; i <= block_size - 16; i += 16) {
+      __m512 src_vec = _mm512_loadu_ps(&block_src[i]);
+      __m512 scaled_vec = _mm512_mul_ps(src_vec, scale_recip_vec);
+      __m512 clamped_vec = _mm512_min_ps(_mm512_max_ps(scaled_vec, neg_quant_max_vec), quant_max_vec);
+      _mm512_storeu_ps(&block_dst[i], clamped_vec);
+    }
+
+    // Handle remaining elements in block
+    for (; i < block_size; ++i) {
+      float scaled = block_src[i] * scale_reciprocal;
+      block_dst[i] = std::clamp(scaled, neg_quant_max, quant_max);
+    }
   });
 }
 
-std::tuple<at::Tensor, at::Tensor> _quantize_fp8e4m3(
-  const at::Tensor& t,
-  bool channelwise,
-  c10::optional<at::Tensor> scale_opt = c10::nullopt
-) {
-  constexpr float quant_max = 448.0f; // torch.finfo(torch.float8_e4m3fn).max
+std::tuple<at::Tensor, at::Tensor>
+_quantize_fp8e4m3(const at::Tensor& t, bool channelwise, c10::optional<at::Tensor> scale_opt = c10::nullopt) {
+  constexpr float quant_max = 448.0f;  // torch.finfo(torch.float8_e4m3fn).max
   constexpr float eps = std::numeric_limits<float>::epsilon();
-  
+
   // Ensure input is contiguous and in float32
   auto t_float = t.to(at::ScalarType::Float).contiguous();
   at::Tensor qt;
   at::Tensor scale_tensor;
-  
+
   if (channelwise) {
-      // Channel-wise quantization with AVX512 optimization
-      int64_t num_channels = t_float.size(0);
-      int64_t elements_per_channel = t_float.numel() / num_channels;
-      
-      if (elements_per_channel * num_channels != t_float.numel()) {
-          throw std::runtime_error("Tensor must be divisible by number of channels for channel-wise quantization");
+    // Channel-wise quantization with AVX512 optimization
+    int64_t num_channels = t_float.size(0);
+    int64_t elements_per_channel = t_float.numel() / num_channels;
+
+    if (elements_per_channel * num_channels != t_float.numel()) {
+      throw std::runtime_error("Tensor must be divisible by number of channels for channel-wise quantization");
+    }
+
+    // Allocate scale tensor
+    scale_tensor = at::empty({num_channels}, t_float.options());
+    float* scale_data = scale_tensor.data_ptr<float>();
+
+    // Compute channel-wise max using AVX512
+    compute_channel_max_avx512(t_float.data_ptr<float>(), scale_data, num_channels, elements_per_channel);
+
+    // Apply quant_max and EPS
+    at::parallel_for(0, num_channels, 1, [&](int64_t start, int64_t end) {
+      for (int64_t c = start; c < end; ++c) {
+        scale_data[c] = std::max(scale_data[c] / quant_max, eps);
       }
-      
-      // Allocate scale tensor
-      scale_tensor = at::empty({num_channels}, t_float.options());
-      float* scale_data = scale_tensor.data_ptr<float>();
-      
-      // Compute channel-wise max using AVX512
-      compute_channel_max_avx512(
-          t_float.data_ptr<float>(),
-          scale_data,
-          num_channels,
-          elements_per_channel
-      );
-      
-      // Apply quant_max and EPS
-      at::parallel_for(0, num_channels, 1, [&](int64_t start, int64_t end) {
-          for (int64_t c = start; c < end; ++c) {
-              scale_data[c] = std::max(scale_data[c] / quant_max, eps);
-          }
-      });
-      
-      // Create output tensor for quantized values
-      qt = at::empty_like(t_float);
-      
-      // Scale and clamp using AVX512
-      scale_clamp_channelwise_avx512(
-          t_float.data_ptr<float>(),
-          qt.data_ptr<float>(),
-          scale_data,
-          num_channels,
-          elements_per_channel,
-          quant_max,
-          -quant_max
-      );
+    });
+
+    // Create output tensor for quantized values
+    qt = at::empty_like(t_float);
+
+    // Scale and clamp using AVX512
+    scale_clamp_channelwise_avx512(
+        t_float.data_ptr<float>(),
+        qt.data_ptr<float>(),
+        scale_data,
+        num_channels,
+        elements_per_channel,
+        quant_max,
+        -quant_max);
   } else {
-      // Global quantization with AVX512 optimization
-      if (!scale_opt.has_value()) {
-          throw std::runtime_error("Scale must be provided for non-channelwise quantization in AVX512 version");
+    // Global quantization with AVX512 optimization
+    if (!scale_opt.has_value()) {
+      throw std::runtime_error("Scale must be provided for non-channelwise quantization in AVX512 version");
+    }
+
+    scale_tensor = scale_opt.value().to(at::ScalarType::Float).contiguous();
+
+    // Handle scalar scale case
+    float scale_val;
+    if (scale_tensor.numel() == 1) {
+      scale_val = std::max(scale_tensor.item<float>(), eps);
+    } else {
+      // Compute max of scale tensor if it's not scalar
+      float* scale_data = scale_tensor.data_ptr<float>();
+      __m512 max_vec = _mm512_set1_ps(eps);
+
+      int64_t i = 0;
+      for (; i <= scale_tensor.numel() - 16; i += 16) {
+        __m512 scale_vec = _mm512_loadu_ps(&scale_data[i]);
+        max_vec = _mm512_max_ps(max_vec, scale_vec);
       }
-      
-      scale_tensor = scale_opt.value().to(at::ScalarType::Float).contiguous();
-      
-      // Handle scalar scale case
-      float scale_val;
-      if (scale_tensor.numel() == 1) {
-          scale_val = std::max(scale_tensor.item<float>(), eps);
-      } else {
-          // Compute max of scale tensor if it's not scalar
-          float* scale_data = scale_tensor.data_ptr<float>();
-          __m512 max_vec = _mm512_set1_ps(eps);
-          
-          int64_t i = 0;
-          for (; i <= scale_tensor.numel() - 16; i += 16) {
-              __m512 scale_vec = _mm512_loadu_ps(&scale_data[i]);
-              max_vec = _mm512_max_ps(max_vec, scale_vec);
-          }
-          
-          float hmax = _mm512_reduce_max_ps(max_vec);
-          for (; i < scale_tensor.numel(); ++i) {
-              hmax = std::max(hmax, scale_data[i]);
-          }
-          scale_val = std::max(hmax, eps);
+
+      float hmax = _mm512_reduce_max_ps(max_vec);
+      for (; i < scale_tensor.numel(); ++i) {
+        hmax = std::max(hmax, scale_data[i]);
       }
-      
-      scale_tensor = at::tensor({scale_val}, scale_tensor.options());
-      float scale_reciprocal = 1.0f / scale_val;
-      
-      // Create output tensor
-      qt = at::empty_like(t_float);
-      
-      // Scale and clamp using AVX512
-      scale_clamp_global_avx512(
-          t_float.data_ptr<float>(),
-          qt.data_ptr<float>(),
-          t_float.numel(),
-          scale_reciprocal,
-          quant_max,
-          -quant_max
-      );
+      scale_val = std::max(hmax, eps);
+    }
+
+    scale_tensor = at::tensor({scale_val}, scale_tensor.options());
+    float scale_reciprocal = 1.0f / scale_val;
+
+    // Create output tensor
+    qt = at::empty_like(t_float);
+
+    // Scale and clamp using AVX512
+    scale_clamp_global_avx512(
+        t_float.data_ptr<float>(), qt.data_ptr<float>(), t_float.numel(), scale_reciprocal, quant_max, -quant_max);
   }
-  
+
   // Final conversion to FP8 E4M3FN using ATen's native conversion
   qt = at::_to_copy(qt, at::ScalarType::Float8_e4m3fn);
-  
+
   return std::make_tuple(qt, scale_tensor);
 }
 
@@ -906,49 +764,49 @@ at::Tensor fp8_scaled_mm_with_quant(
 }
 
 at::Tensor float8_linear_impl(
-  const at::Tensor& input,
-  const at::Tensor& input_scales,
-  const at::Tensor& weight,
-  const at::Tensor& weight_scales,
-  const std::optional<at::Tensor>& bias,
-  at::ScalarType output_dtype) {
-int64_t N = weight.dim() == 4 ? weight.size(0) * weight.size(-1) : weight.size(0);
-int act_quant_mode = input_scales.numel() == 1                                ? PER_TENSOR
-                     : input_scales.numel() == input.numel() / input.size(-1) ? PER_ROW
-                                                                              : PER_GROUP;
-int wei_quant_mode = weight_scales.numel() == 1 ? PER_TENSOR : weight_scales.numel() == N ? PER_ROW : PER_GROUP;
-// Case to fall back
-if (weight.dim() == 2) {
-  TORCH_CHECK(
-      act_quant_mode != PER_GROUP && wei_quant_mode != PER_GROUP,
-      "FP8 linear: Per-group quantization is not supported in the fallback path");
-  auto y_fp32 = at::linear(input.to(at::kFloat).mul_(input_scales), weight.to(at::kFloat).mul_(weight_scales), bias);
-  return y_fp32.to(output_dtype);
-}
+    const at::Tensor& input,
+    const at::Tensor& input_scales,
+    const at::Tensor& weight,
+    const at::Tensor& weight_scales,
+    const std::optional<at::Tensor>& bias,
+    at::ScalarType output_dtype) {
+  int64_t N = weight.dim() == 4 ? weight.size(0) * weight.size(-1) : weight.size(0);
+  int act_quant_mode = input_scales.numel() == 1                                ? PER_TENSOR
+                       : input_scales.numel() == input.numel() / input.size(-1) ? PER_ROW
+                                                                                : PER_GROUP;
+  int wei_quant_mode = weight_scales.numel() == 1 ? PER_TENSOR : weight_scales.numel() == N ? PER_ROW : PER_GROUP;
+  // Case to fall back
+  if (weight.dim() == 2) {
+    TORCH_CHECK(
+        act_quant_mode != PER_GROUP && wei_quant_mode != PER_GROUP,
+        "FP8 linear: Per-group quantization is not supported in the fallback path");
+    auto y_fp32 = at::linear(input.to(at::kFloat).mul_(input_scales), weight.to(at::kFloat).mul_(weight_scales), bias);
+    return y_fp32.to(output_dtype);
+  }
 
-static bool cpublas_can_pack = cpublas_could_pack();
-auto out_sizes = input.sizes().vec();
-out_sizes.back() = N;
-auto output = at::empty(out_sizes, input.options().dtype(output_dtype));
+  static bool cpublas_can_pack = cpublas_could_pack();
+  auto out_sizes = input.sizes().vec();
+  out_sizes.back() = N;
+  auto output = at::empty(out_sizes, input.options().dtype(output_dtype));
 
 #define AT_DISPATCH_FP8_LINEAR_KERNEL(OUT_DTYPE, CAN_PACK, A_QUANT_MODE, B_QUANT_MODE, ...) \
-AT_DISPATCH_BOOL_NO_RETURN(                                                               \
-    CAN_PACK,                                                                             \
-    "cpublas_can_pack",                                                                   \
-    can_pack,                                                                             \
-    AT_DISPATCH_QUANT_MODE_NO_RETURN(                                                     \
-        A_QUANT_MODE,                                                                     \
-        "act_quant_mode",                                                                 \
-        a_quant_mode,                                                                     \
-        AT_DISPATCH_QUANT_MODE_NO_RETURN(                                                 \
-            B_QUANT_MODE,                                                                 \
-            "wei_quant_mode",                                                             \
-            b_quant_mode,                                                                 \
-            AT_DISPATCH_OUT_TYPES(OUT_DTYPE, "out_dtype", __VA_ARGS__))))
+  AT_DISPATCH_BOOL_NO_RETURN(                                                               \
+      CAN_PACK,                                                                             \
+      "cpublas_can_pack",                                                                   \
+      can_pack,                                                                             \
+      AT_DISPATCH_QUANT_MODE_NO_RETURN(                                                     \
+          A_QUANT_MODE,                                                                     \
+          "act_quant_mode",                                                                 \
+          a_quant_mode,                                                                     \
+          AT_DISPATCH_QUANT_MODE_NO_RETURN(                                                 \
+              B_QUANT_MODE,                                                                 \
+              "wei_quant_mode",                                                             \
+              b_quant_mode,                                                                 \
+              AT_DISPATCH_OUT_TYPES(OUT_DTYPE, "out_dtype", __VA_ARGS__))))
 
-AT_DISPATCH_FP8_LINEAR_KERNEL(output_dtype, cpublas_can_pack, act_quant_mode, wei_quant_mode, [&]() {
-  _float8_linear_impl<out_t, can_pack, a_quant_mode, b_quant_mode>(
-      input, input_scales, weight, weight_scales, bias, output);
-});
-return output;
+  AT_DISPATCH_FP8_LINEAR_KERNEL(output_dtype, cpublas_can_pack, act_quant_mode, wei_quant_mode, [&]() {
+    _float8_linear_impl<out_t, can_pack, a_quant_mode, b_quant_mode>(
+        input, input_scales, weight, weight_scales, bias, output);
+  });
+  return output;
 }

--- a/sgl-kernel/csrc/cpu/gemm_fp8_w8a8.cpp
+++ b/sgl-kernel/csrc/cpu/gemm_fp8_w8a8.cpp
@@ -407,7 +407,7 @@ void _float8_linear_impl(
 }  // anonymous namespace
 
 
-template <bool cpublas_can_pack, int64_t N, int act_quant_mode, int wei_quant_mode>
+// template <bool cpublas_can_pack, int64_t N, int act_quant_mode, int wei_quant_mode>
 void tinygemm_kernel2(
     float* C,
     const at::Float8_e4m3fn* A,
@@ -422,9 +422,27 @@ void tinygemm_kernel2(
     float* ukernel_buf,
     at::BFloat16* dqA_buf,
     at::BFloat16* dqB_buf) {
-
-    return _micro_gemm<cpublas_can_pack, N, act_quant_mode, wei_quant_mode>(C, A, scales_a, B, scales_b, M, K, lda, ldc, ldsa, ukernel_buf,dqA_buf, dqB_buf );
+    // const N = block_n
+     _micro_gemm<true, BLOCK_N, 2, 3>(C, A, scales_a, B, scales_b, M, K, lda, ldc, ldsa, ukernel_buf,dqA_buf, dqB_buf );
     }
+
+#define INSTANTIATE_TINYGEMM_TEMPLATE()    \
+ void tinygemm_kernel2(         \
+    float* C, \
+    const at::Float8_e4m3fn* A,\
+    const float* scales_a,\
+    const at::Float8_e4m3fn* B,\
+    const float* scales_b,\
+    int64_t M,\
+    int64_t K,\
+    int64_t lda,\
+    int64_t ldc,\
+    int64_t ldsa,\
+    float* ukernel_buf,\
+    at::BFloat16* dqA_buf,\
+    at::BFloat16* dqB_buf)
+
+INSTANTIATE_TINYGEMM_TEMPLATE();
 /*
 return: packed_weight, packed_scales
 */
@@ -462,7 +480,7 @@ std::tuple<at::Tensor, at::Tensor> float8_linear_prepack_impl(const at::Tensor& 
 
 #if defined(CPU_CAPABILITY_AVX512)
   if (cpublas_could_pack()) {
-#ifdef CPUBLAS_BRGEMM_F8F8BF16
+#ifdef CPUBLAS_BRGEMM_F8F8F32
     constexpr int vnni_size = 4;  // for fp8
 #else
     constexpr int vnni_size = 2;  // for float16
@@ -503,13 +521,349 @@ std::tuple<at::Tensor, at::Tensor> float8_linear_prepack_impl(const at::Tensor& 
   return std::make_tuple(std::move(blocked_weight), std::move(blocked_scales));
 }
 
-at::Tensor float8_linear_impl(
-    const at::Tensor& input,
-    const at::Tensor& input_scales,
+// Helper function for AVX512 scaling and clamping (FP32 -> FP32, then ATen converts to FP8)
+inline void scale_clamp_block_avx512(
+  const float* src, float* dst, int64_t size, float scale_reciprocal, float quant_max, float neg_quant_max) {
+  if (size <= 0) return;
+  
+  const __m512 scale_recip_vec = _mm512_set1_ps(scale_reciprocal);
+  const __m512 quant_max_vec = _mm512_set1_ps(quant_max);
+  const __m512 neg_quant_max_vec = _mm512_set1_ps(neg_quant_max);
+  
+  int64_t i = 0;
+  // Process 16 elements at a time (AVX512 width)
+  for (; i <= size - 16; i += 16) {
+      __m512 src_vec = _mm512_loadu_ps(&src[i]);
+      __m512 scaled_vec = _mm512_mul_ps(src_vec, scale_recip_vec);
+      __m512 clamped_vec = _mm512_min_ps(_mm512_max_ps(scaled_vec, neg_quant_max_vec), quant_max_vec);
+      _mm512_storeu_ps(&dst[i], clamped_vec);
+  }
+  
+  // Handle remaining elements
+  for (; i < size; ++i) {
+      float scaled = src[i] * scale_reciprocal;
+      dst[i] = std::clamp(scaled, neg_quant_max, quant_max);
+  }
+}
+
+std::tuple<at::Tensor, at::Tensor> _quantize_fp8e4m3_(
+  const at::Tensor& t,
+  bool channelwise,
+  c10::optional<at::Tensor> scale_opt = c10::nullopt
+) {
+  constexpr float quant_max = 448.0f; // torch.finfo(torch.float8_e4m3fn).max
+  constexpr float eps = std::numeric_limits<float>::epsilon();
+  
+  // Ensure input is contiguous and in float32 for processing
+  auto t_float = t.to(at::ScalarType::Float).contiguous();
+  at::Tensor qt;
+  at::Tensor scale_tensor;
+  
+  if (channelwise) {
+      if (!scale_opt.has_value()) {
+          // Compute scale per channel using parallel processing
+          int64_t num_channels = t_float.size(0);
+          scale_tensor = at::empty({num_channels}, t_float.options());
+          
+          at::parallel_for(0, num_channels, 1, [&](int64_t start, int64_t end) {
+              for (int64_t c = start; c < end; ++c) {
+                  auto channel_view = t_float.select(0, c);
+                  float channel_max = channel_view.abs().max().item<float>();
+                  scale_tensor[c] = std::max(channel_max / quant_max, eps);
+              }
+          });
+      } else {
+          scale_tensor = scale_opt.value().to(at::ScalarType::Float);
+          auto eps_tensor = at::full_like(scale_tensor, eps);
+          scale_tensor = at::where(scale_tensor > eps_tensor, scale_tensor, eps_tensor);
+      }
+      
+      // Reshape scale for broadcasting
+      std::vector<int64_t> scale_shape(t_float.dim(), 1);
+      scale_shape[0] = scale_tensor.size(0);
+      auto scale_reshaped = scale_tensor.reshape(scale_shape);
+      
+      // Quantize using vectorized division
+      qt = t_float / scale_reshaped;
+  } else {
+      if (!scale_opt.has_value()) {
+          // Compute global scale using vectorized max
+          float abs_max = t_float.abs().max().item<float>();
+          scale_tensor = at::tensor({std::max(abs_max / quant_max, eps)}, 
+                                   t_float.options().device(t_float.device()));
+          
+          // Vectorized quantization
+          qt = t_float / scale_tensor.item<float>();
+      } else {
+          scale_tensor = scale_opt.value().to(at::ScalarType::Float);
+          float scale_val;
+          
+          if (scale_tensor.numel() == 1) {
+              // Handle scalar tensor case
+              if (scale_tensor.scalar_type() == at::ScalarType::Float) {
+                  scale_val = std::max(scale_tensor.item<float>(), eps);
+              } else if (scale_tensor.scalar_type() == at::ScalarType::Double) {
+                  scale_val = std::max(scale_tensor.item<double>(), static_cast<double>(eps));
+              } else {
+                  scale_val = std::max(scale_tensor.item<float>(), eps);
+              }
+          } else {
+              // Handle tensor case - take max of all elements
+              float tensor_max = scale_tensor.max().item<float>();
+              scale_val = std::max(tensor_max, eps);
+          }
+          
+          scale_tensor = at::tensor({scale_val}, scale_tensor.options());
+          float scale_reciprocal = 1.0f / scale_val;
+          
+          // Create output tensor for quantized values
+          qt = at::empty_like(t_float);
+          
+          if (t_float.is_contiguous() && t_float.numel() >= 64 ) {
+              // AVX512 optimized path for scaling and clamping
+              at::parallel_for(0, t_float.numel(), 4096, [&](int64_t start, int64_t end) {
+                  int64_t block_size = end - start;
+                  scale_clamp_block_avx512(
+                      t_float.data_ptr<float>() + start,
+                      qt.data_ptr<float>() + start,
+                      block_size,
+                      scale_reciprocal,
+                      quant_max,
+                      -quant_max
+                  );
+              });
+          } else {
+              // Scale the tensor
+              qt = at::div(t_float, scale_val);
+              // Clamp to FP8 range
+              qt = at::clamp(qt, -quant_max, quant_max);
+          }
+      }
+  }
+  
+  // Final conversion to FP8 E4M3FN using ATen's native conversion
+  qt = at::_to_copy(qt, at::ScalarType::Float8_e4m3fn);
+  return std::make_tuple(qt, scale_tensor);
+}
+
+
+// AVX512 optimized channel-wise max computation
+inline void compute_channel_max_avx512(
+  const float* data, float* max_vals, int64_t num_channels, int64_t elements_per_channel) {
+  at::parallel_for(0, num_channels, 1, [&](int64_t start, int64_t end) {
+      for (int64_t c = start; c < end; ++c) {
+          const float* channel_data = data + c * elements_per_channel;
+          float max_val = 0.0f;
+          
+          int64_t i = 0;
+          // Process 16 elements at a time
+          __m512 max_vec = _mm512_setzero_ps();
+          
+          for (; i <= elements_per_channel - 16; i += 16) {
+              __m512 data_vec = _mm512_loadu_ps(&channel_data[i]);
+              __m512 abs_vec = _mm512_abs_ps(data_vec);
+              max_vec = _mm512_max_ps(max_vec, abs_vec);
+          }
+          
+          // Horizontal max of the vector
+          float hmax = _mm512_reduce_max_ps(max_vec);
+          max_val = std::max(max_val, hmax);
+          
+          // Handle remaining elements
+          for (; i < elements_per_channel; ++i) {
+              max_val = std::max(max_val, std::abs(channel_data[i]));
+          }
+          
+          max_vals[c] = max_val;
+      }
+  });
+}
+
+// AVX512 optimized scaling and clamping for channel-wise quantization
+inline void scale_clamp_channelwise_avx512(
+  const float* src, float* dst, const float* scales, 
+  int64_t num_channels, int64_t elements_per_channel, 
+  float quant_max, float neg_quant_max) {
+  
+  at::parallel_for(0, num_channels, 1, [&](int64_t start, int64_t end) {
+      for (int64_t c = start; c < end; ++c) {
+          float scale_val = scales[c];
+          float scale_reciprocal = 1.0f / scale_val;
+          
+          const float* channel_src = src + c * elements_per_channel;
+          float* channel_dst = dst + c * elements_per_channel;
+          
+          int64_t i = 0;
+          const __m512 scale_recip_vec = _mm512_set1_ps(scale_reciprocal);
+          const __m512 quant_max_vec = _mm512_set1_ps(quant_max);
+          const __m512 neg_quant_max_vec = _mm512_set1_ps(neg_quant_max);
+          
+          for (; i <= elements_per_channel - 16; i += 16) {
+              __m512 src_vec = _mm512_loadu_ps(&channel_src[i]);
+              __m512 scaled_vec = _mm512_mul_ps(src_vec, scale_recip_vec);
+              __m512 clamped_vec = _mm512_min_ps(_mm512_max_ps(scaled_vec, neg_quant_max_vec), quant_max_vec);
+              _mm512_storeu_ps(&channel_dst[i], clamped_vec);
+          }
+          
+          // Handle remaining elements
+          for (; i < elements_per_channel; ++i) {
+              float scaled = channel_src[i] * scale_reciprocal;
+              channel_dst[i] = std::clamp(scaled, neg_quant_max, quant_max);
+          }
+      }
+  });
+}
+
+// AVX512 optimized scaling and clamping for global quantization
+inline void scale_clamp_global_avx512(
+  const float* src, float* dst, int64_t size, 
+  float scale_reciprocal, float quant_max, float neg_quant_max) {
+  
+  if (size <= 0) return;
+  
+  const __m512 scale_recip_vec = _mm512_set1_ps(scale_reciprocal);
+  const __m512 quant_max_vec = _mm512_set1_ps(quant_max);
+  const __m512 neg_quant_max_vec = _mm512_set1_ps(neg_quant_max);
+  
+  at::parallel_for(0, size, 4096, [&](int64_t start, int64_t end) {
+      int64_t block_size = end - start;
+      const float* block_src = src + start;
+      float* block_dst = dst + start;
+      
+      int64_t i = 0;
+      for (; i <= block_size - 16; i += 16) {
+          __m512 src_vec = _mm512_loadu_ps(&block_src[i]);
+          __m512 scaled_vec = _mm512_mul_ps(src_vec, scale_recip_vec);
+          __m512 clamped_vec = _mm512_min_ps(_mm512_max_ps(scaled_vec, neg_quant_max_vec), quant_max_vec);
+          _mm512_storeu_ps(&block_dst[i], clamped_vec);
+      }
+      
+      // Handle remaining elements in block
+      for (; i < block_size; ++i) {
+          float scaled = block_src[i] * scale_reciprocal;
+          block_dst[i] = std::clamp(scaled, neg_quant_max, quant_max);
+      }
+  });
+}
+
+std::tuple<at::Tensor, at::Tensor> _quantize_fp8e4m3(
+  const at::Tensor& t,
+  bool channelwise,
+  c10::optional<at::Tensor> scale_opt = c10::nullopt
+) {
+  constexpr float quant_max = 448.0f; // torch.finfo(torch.float8_e4m3fn).max
+  constexpr float eps = std::numeric_limits<float>::epsilon();
+  
+  // Ensure input is contiguous and in float32
+  auto t_float = t.to(at::ScalarType::Float).contiguous();
+  at::Tensor qt;
+  at::Tensor scale_tensor;
+  
+  if (channelwise) {
+      // Channel-wise quantization with AVX512 optimization
+      int64_t num_channels = t_float.size(0);
+      int64_t elements_per_channel = t_float.numel() / num_channels;
+      
+      if (elements_per_channel * num_channels != t_float.numel()) {
+          throw std::runtime_error("Tensor must be divisible by number of channels for channel-wise quantization");
+      }
+      
+      // Allocate scale tensor
+      scale_tensor = at::empty({num_channels}, t_float.options());
+      float* scale_data = scale_tensor.data_ptr<float>();
+      
+      // Compute channel-wise max using AVX512
+      compute_channel_max_avx512(
+          t_float.data_ptr<float>(),
+          scale_data,
+          num_channels,
+          elements_per_channel
+      );
+      
+      // Apply quant_max and EPS
+      at::parallel_for(0, num_channels, 1, [&](int64_t start, int64_t end) {
+          for (int64_t c = start; c < end; ++c) {
+              scale_data[c] = std::max(scale_data[c] / quant_max, eps);
+          }
+      });
+      
+      // Create output tensor for quantized values
+      qt = at::empty_like(t_float);
+      
+      // Scale and clamp using AVX512
+      scale_clamp_channelwise_avx512(
+          t_float.data_ptr<float>(),
+          qt.data_ptr<float>(),
+          scale_data,
+          num_channels,
+          elements_per_channel,
+          quant_max,
+          -quant_max
+      );
+  } else {
+      // Global quantization with AVX512 optimization
+      if (!scale_opt.has_value()) {
+          throw std::runtime_error("Scale must be provided for non-channelwise quantization in AVX512 version");
+      }
+      
+      scale_tensor = scale_opt.value().to(at::ScalarType::Float).contiguous();
+      
+      // Handle scalar scale case
+      float scale_val;
+      if (scale_tensor.numel() == 1) {
+          scale_val = std::max(scale_tensor.item<float>(), eps);
+      } else {
+          // Compute max of scale tensor if it's not scalar
+          float* scale_data = scale_tensor.data_ptr<float>();
+          __m512 max_vec = _mm512_set1_ps(eps);
+          
+          int64_t i = 0;
+          for (; i <= scale_tensor.numel() - 16; i += 16) {
+              __m512 scale_vec = _mm512_loadu_ps(&scale_data[i]);
+              max_vec = _mm512_max_ps(max_vec, scale_vec);
+          }
+          
+          float hmax = _mm512_reduce_max_ps(max_vec);
+          for (; i < scale_tensor.numel(); ++i) {
+              hmax = std::max(hmax, scale_data[i]);
+          }
+          scale_val = std::max(hmax, eps);
+      }
+      
+      scale_tensor = at::tensor({scale_val}, scale_tensor.options());
+      float scale_reciprocal = 1.0f / scale_val;
+      
+      // Create output tensor
+      qt = at::empty_like(t_float);
+      
+      // Scale and clamp using AVX512
+      scale_clamp_global_avx512(
+          t_float.data_ptr<float>(),
+          qt.data_ptr<float>(),
+          t_float.numel(),
+          scale_reciprocal,
+          quant_max,
+          -quant_max
+      );
+  }
+  
+  // Final conversion to FP8 E4M3FN using ATen's native conversion
+  qt = at::_to_copy(qt, at::ScalarType::Float8_e4m3fn);
+  
+  return std::make_tuple(qt, scale_tensor);
+}
+
+at::Tensor fp8_scaled_mm_with_quant(
+    const at::Tensor& act,
+    const std::optional<at::Tensor>& act_scales,
+    bool channelwise,
     const at::Tensor& weight,
     const at::Tensor& weight_scales,
     const std::optional<at::Tensor>& bias,
     at::ScalarType output_dtype) {
+  std::tuple<at::Tensor, at::Tensor> quant_act = _quantize_fp8e4m3(act, channelwise, act_scales);
+  auto input = std::get<0>(quant_act);
+  auto input_scales = std::get<1>(quant_act);
   int64_t N = weight.dim() == 4 ? weight.size(0) * weight.size(-1) : weight.size(0);
   int act_quant_mode = input_scales.numel() == 1                                ? PER_TENSOR
                        : input_scales.numel() == input.numel() / input.size(-1) ? PER_ROW
@@ -549,4 +903,52 @@ at::Tensor float8_linear_impl(
         input, input_scales, weight, weight_scales, bias, output);
   });
   return output;
+}
+
+at::Tensor float8_linear_impl(
+  const at::Tensor& input,
+  const at::Tensor& input_scales,
+  const at::Tensor& weight,
+  const at::Tensor& weight_scales,
+  const std::optional<at::Tensor>& bias,
+  at::ScalarType output_dtype) {
+int64_t N = weight.dim() == 4 ? weight.size(0) * weight.size(-1) : weight.size(0);
+int act_quant_mode = input_scales.numel() == 1                                ? PER_TENSOR
+                     : input_scales.numel() == input.numel() / input.size(-1) ? PER_ROW
+                                                                              : PER_GROUP;
+int wei_quant_mode = weight_scales.numel() == 1 ? PER_TENSOR : weight_scales.numel() == N ? PER_ROW : PER_GROUP;
+// Case to fall back
+if (weight.dim() == 2) {
+  TORCH_CHECK(
+      act_quant_mode != PER_GROUP && wei_quant_mode != PER_GROUP,
+      "FP8 linear: Per-group quantization is not supported in the fallback path");
+  auto y_fp32 = at::linear(input.to(at::kFloat).mul_(input_scales), weight.to(at::kFloat).mul_(weight_scales), bias);
+  return y_fp32.to(output_dtype);
+}
+
+static bool cpublas_can_pack = cpublas_could_pack();
+auto out_sizes = input.sizes().vec();
+out_sizes.back() = N;
+auto output = at::empty(out_sizes, input.options().dtype(output_dtype));
+
+#define AT_DISPATCH_FP8_LINEAR_KERNEL(OUT_DTYPE, CAN_PACK, A_QUANT_MODE, B_QUANT_MODE, ...) \
+AT_DISPATCH_BOOL_NO_RETURN(                                                               \
+    CAN_PACK,                                                                             \
+    "cpublas_can_pack",                                                                   \
+    can_pack,                                                                             \
+    AT_DISPATCH_QUANT_MODE_NO_RETURN(                                                     \
+        A_QUANT_MODE,                                                                     \
+        "act_quant_mode",                                                                 \
+        a_quant_mode,                                                                     \
+        AT_DISPATCH_QUANT_MODE_NO_RETURN(                                                 \
+            B_QUANT_MODE,                                                                 \
+            "wei_quant_mode",                                                             \
+            b_quant_mode,                                                                 \
+            AT_DISPATCH_OUT_TYPES(OUT_DTYPE, "out_dtype", __VA_ARGS__))))
+
+AT_DISPATCH_FP8_LINEAR_KERNEL(output_dtype, cpublas_can_pack, act_quant_mode, wei_quant_mode, [&]() {
+  _float8_linear_impl<out_t, can_pack, a_quant_mode, b_quant_mode>(
+      input, input_scales, weight, weight_scales, bias, output);
+});
+return output;
 }

--- a/sgl-kernel/csrc/cpu/gemm_fp8_w8a8.cpp
+++ b/sgl-kernel/csrc/cpu/gemm_fp8_w8a8.cpp
@@ -711,6 +711,236 @@ _quantize_fp8e4m3(const at::Tensor& t, bool channelwise, c10::optional<at::Tenso
   return std::make_tuple(qt, scale_tensor);
 }
 
+inline __m128i cvtfp32_fp8e4m3(__m512& src) {
+  // cvt 16x32 from fp32 to fp8 e4m3
+  const __m512i sign_mask = _mm512_set1_epi32(0x80000000);
+  const __m512i fp8_max = _mm512_set1_epi32(UINT32_C(1087) << 20);
+  const __m512i denorm_thresh = _mm512_set1_epi32(UINT32_C(121) << 23);
+  const __m512i denorm_mask = _mm512_set1_epi32(UINT32_C(141) << 23);
+  const __m512i bias_part1 = _mm512_set1_epi32((uint32_t)(7 - 127) << 23);
+  const __m512i rounding_bias = _mm512_set1_epi32(0x7FFFF);
+  __m512i f_bits = _mm512_castps_si512(src);
+  // Extract and save sign
+  __m512i sign = _mm512_and_epi32(f_bits, sign_mask);
+  f_bits = _mm512_xor_epi32(f_bits, sign);
+
+  // Prepare result containers
+  __m512i result = _mm512_setzero_si512();
+
+  // Step 1: Handle case of overflow
+  // (f_bits >= fp8_max): set result = 0x7f
+  __mmask16 overflow_mask = _mm512_cmpge_epu32_mask(f_bits, fp8_max);
+  if (overflow_mask) {
+    result = _mm512_mask_set1_epi32(result, overflow_mask, 0x7f);
+  }
+
+  // Step 2: Handle small numbers (denormals)
+  // Small numbers (f_bits < denorm_thresh)
+  __mmask16 denorm_thresh_mask = _mm512_cmplt_epu32_mask(f_bits, denorm_thresh);
+
+  if (denorm_thresh_mask) {
+    __m512 small_input = _mm512_castsi512_ps(f_bits);
+    __m512 small_denorm = _mm512_add_ps(small_input, _mm512_castsi512_ps(denorm_mask));
+    __m512i small_denorm_bits = _mm512_castps_si512(small_denorm);
+    __m512i small_result = _mm512_sub_epi32(small_denorm_bits, denorm_mask);
+    result = _mm512_mask_mov_epi32(result, denorm_thresh_mask, small_result);
+  }
+
+  // Step 3: Handle normal numbers
+  __mmask16 normal_mask = ~(overflow_mask | denorm_thresh_mask);
+
+  if (normal_mask) {
+    // mant_odd = (f_bits >> 20) & 1
+    __m512i mant_odd = _mm512_and_epi32(_mm512_srli_epi32(f_bits, 20), _mm512_set1_epi32(1));
+    // f_bits += bias_part1 + rounding_bias
+    __m512i rounded = _mm512_add_epi32(f_bits, bias_part1);
+    rounded = _mm512_add_epi32(rounded, rounding_bias);
+    // Add mant_odd
+    rounded = _mm512_add_epi32(rounded, mant_odd);
+    // Shift right by 20 bits
+    __m512i normal_result = _mm512_srli_epi32(rounded, 20);
+    result = _mm512_mask_mov_epi32(result, normal_mask, normal_result);
+  }
+
+  // Merge back the sign
+  __m512i sign_shifted = _mm512_srli_epi32(sign, 24);
+  result = _mm512_or_epi32(result, sign_shifted);
+
+  // Now result is 16 x 32-bit integers, but we only need 8-bit for each
+  __m512i packed = _mm512_and_si512(result, _mm512_set1_epi32(0xFF));
+
+  // Narrow 32-bit integers to 8-bit
+  return _mm512_cvtepi32_epi8(packed);
+}
+
+std::tuple<at::Tensor, at::Tensor> _quantize_fp8e4m3_bf16_per_tensor_no_scale(const at::Tensor& t) {
+  constexpr float quant_max = 448.0f;  // torch.finfo(torch.float8_e4m3fn).max
+  constexpr float eps = std::numeric_limits<float>::epsilon();
+
+  // Input validation and preparation
+  assert(t.scalar_type() == at::ScalarType::BFloat16);
+  auto t_bf16 = t.contiguous();
+  int64_t num_channels = t_bf16.size(0);
+  int64_t elements_per_channel = t_bf16.numel() / num_channels;
+  assert(elements_per_channel % 32 == 0);  // do not consider tile currently
+  at::Tensor quant_t = at::empty_like(t_bf16).to(at::kFloat8_e4m3fn);
+
+  // Allocate output tensors
+  at::Tensor scale_tensor = at::empty({num_channels}, t_bf16.options().dtype(at::ScalarType::Float));
+  float* scale_data = scale_tensor.data_ptr<float>();
+
+  // Unified processing: compute max, apply scale, and quantize in single pass
+  at::parallel_for(0, num_channels, 1, [&](int64_t start, int64_t end) {
+    for (int64_t c = start; c < end; ++c) {
+      const at::BFloat16* channel_src = t_bf16.data_ptr<at::BFloat16>() + c * elements_per_channel;
+      at::Float8_e4m3fn* quant_dst = quant_t.data_ptr<at::Float8_e4m3fn>() + c * elements_per_channel;
+
+      // Step 1: Compute channel-wise max using AVX512
+      float channel_max = 0.0f;
+      int64_t i = 0;
+
+      // Process 32 elements at a time for max computation
+      for (; i <= elements_per_channel - 32; i += 32) {
+        // Load 32 BF16 values (2x 256-bit vectors)
+        __m256i src_vec1 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(&channel_src[i]));
+        __m256i src_vec2 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(&channel_src[i + 16]));
+
+        // Convert BF16 to FP32
+        __m512i fp32_int1 = _mm512_cvtepu16_epi32(src_vec1);
+        __m512 fp32_vec1 = _mm512_castsi512_ps(_mm512_slli_epi32(fp32_int1, 16));
+
+        __m512i fp32_int2 = _mm512_cvtepu16_epi32(src_vec2);
+        __m512 fp32_vec2 = _mm512_castsi512_ps(_mm512_slli_epi32(fp32_int2, 16));
+
+        // Compute absolute values
+        __m512 abs_vec1 = _mm512_abs_ps(fp32_vec1);
+        __m512 abs_vec2 = _mm512_abs_ps(fp32_vec2);
+
+        // Find max in each vector
+        float max1 = _mm512_reduce_max_ps(abs_vec1);
+        float max2 = _mm512_reduce_max_ps(abs_vec2);
+        channel_max = std::max(channel_max, std::max(max1, max2));
+      }
+
+      // Step 2: Apply quant_max and EPS to compute scale
+      float scale_val = std::max(channel_max / quant_max, eps);
+      float scale_reciprocal = 1.0f / scale_val;
+      scale_data[c] = scale_val;
+
+      // Step 3: Scale and clamp using AVX512 (reuse the same loop structure)
+      i = 0;
+      const __m512 scale_recip_vec = _mm512_set1_ps(scale_reciprocal);
+      const __m512 quant_max_vec = _mm512_set1_ps(quant_max);
+      const __m512 neg_quant_max_vec = _mm512_set1_ps(-quant_max);
+
+      for (; i <= elements_per_channel - 32; i += 32) {
+        // Load 32 BF16 values
+        __m256i src_vec1 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(&channel_src[i]));
+        __m256i src_vec2 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(&channel_src[i + 16]));
+
+        // Convert BF16 to FP32
+        __m512 fp32_vec1 = _mm512_castsi512_ps(_mm512_slli_epi32(_mm512_cvtepu16_epi32(src_vec1), 16));
+        __m512 fp32_vec2 = _mm512_castsi512_ps(_mm512_slli_epi32(_mm512_cvtepu16_epi32(src_vec2), 16));
+
+        // Scale and clamp
+        __m512 scaled_vec1 = _mm512_mul_ps(fp32_vec1, scale_recip_vec);
+        __m512 clamped_vec1 = _mm512_min_ps(_mm512_max_ps(scaled_vec1, neg_quant_max_vec), quant_max_vec);
+
+        __m512 scaled_vec2 = _mm512_mul_ps(fp32_vec2, scale_recip_vec);
+        __m512 clamped_vec2 = _mm512_min_ps(_mm512_max_ps(scaled_vec2, neg_quant_max_vec), quant_max_vec);
+
+        __m128i fp8_vec1 = cvtfp32_fp8e4m3(clamped_vec1);
+        __m128i fp8_vec2 = cvtfp32_fp8e4m3(clamped_vec2);
+        _mm_storeu_si128(reinterpret_cast<__m128i*>(quant_dst + i), fp8_vec1);
+        _mm_storeu_si128(reinterpret_cast<__m128i*>(quant_dst + i + 16), fp8_vec2);
+      }
+    }
+  });
+
+  return std::make_tuple(quant_t, scale_tensor);
+}
+
+std::tuple<at::Tensor, at::Tensor>
+_quantize_fp8e4m3_bf16_per_tensor_with_scale(const at::Tensor& t, at::Tensor& scale_tensor) {
+  constexpr float quant_max = 448.0f;  // torch.finfo(torch.float8_e4m3fn).max
+  constexpr float eps = std::numeric_limits<float>::epsilon();
+
+  // Input validation
+  assert(t.scalar_type() == at::ScalarType::BFloat16);
+
+  auto t_bf16 = t.contiguous();
+  auto scale_tensor_contig = scale_tensor.contiguous().to(at::ScalarType::Float);
+
+  // Get scale value (handle scalar or tensor)
+  float scale_val;
+  if (scale_tensor_contig.numel() == 1) {
+    scale_val = scale_tensor_contig.item<float>();
+  } else {
+    // Take max if scale is a tensor (though should be scalar for global quantization)
+    scale_val = scale_tensor_contig.max().item<float>();
+  }
+
+  // Apply EPS to scale
+  scale_val = std::max(scale_val, eps);
+  float scale_reciprocal = 1.0f / scale_val;
+
+  at::Tensor scale_output = at::tensor({scale_val}, scale_tensor_contig.options());
+
+  // Apply scale and clamp using AVX512
+  const at::BFloat16* src_data = t_bf16.data_ptr<at::BFloat16>();
+  at::Tensor quant_t = at::empty_like(t_bf16).to(at::kFloat8_e4m3fn);
+  int64_t total_elements = t_bf16.numel();
+  const __m512 scale_recip_vec = _mm512_set1_ps(scale_reciprocal);
+  const __m512 quant_max_vec = _mm512_set1_ps(quant_max);
+  const __m512 neg_quant_max_vec = _mm512_set1_ps(-quant_max);
+  int64_t num_channels = t_bf16.size(0);
+  int64_t elements_per_channel = total_elements / num_channels;
+  assert(elements_per_channel % 32 == 0);  // do not consider tile currently
+  // Process in parallel blocks
+  at::parallel_for(0, num_channels, 1, [&](int64_t start, int64_t end) {
+    for (int64_t c = start; c < end; ++c) {
+      const at::BFloat16* src_data = t_bf16.data_ptr<at::BFloat16>() + c * elements_per_channel;
+      at::Float8_e4m3fn* quant_t_data = quant_t.data_ptr<at::Float8_e4m3fn>() + c * elements_per_channel;
+
+      int64_t i = 0;
+      // Process 32 elements at a time using AVX512
+      for (; i <= elements_per_channel - 32; i += 32) {
+        // Load 32 BF16 values (2x 256-bit vectors)
+        __m256i src_vec1 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(&src_data[i]));
+        __m256i src_vec2 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(&src_data[i + 16]));
+
+        // Convert BF16 to FP32
+        __m512 fp32_vec1 = _mm512_castsi512_ps(_mm512_slli_epi32(_mm512_cvtepu16_epi32(src_vec1), 16));
+        __m512 fp32_vec2 = _mm512_castsi512_ps(_mm512_slli_epi32(_mm512_cvtepu16_epi32(src_vec2), 16));
+
+        // Scale and clamp
+        __m512 scaled_vec1 = _mm512_mul_ps(fp32_vec1, scale_recip_vec);
+        __m512 clamped_vec1 = _mm512_min_ps(_mm512_max_ps(scaled_vec1, neg_quant_max_vec), quant_max_vec);
+
+        __m512 scaled_vec2 = _mm512_mul_ps(fp32_vec2, scale_recip_vec);
+        __m512 clamped_vec2 = _mm512_min_ps(_mm512_max_ps(scaled_vec2, neg_quant_max_vec), quant_max_vec);
+
+        __m128i fp8_vec1 = cvtfp32_fp8e4m3(clamped_vec1);
+        __m128i fp8_vec2 = cvtfp32_fp8e4m3(clamped_vec2);
+        _mm_storeu_si128(reinterpret_cast<__m128i*>(quant_t_data + i), fp8_vec1);
+        _mm_storeu_si128(reinterpret_cast<__m128i*>(quant_t_data + i + 16), fp8_vec2);
+      }
+    }
+  });
+
+  return std::make_tuple(quant_t, scale_output);
+}
+
+std::tuple<at::Tensor, at::Tensor>
+_quantize_fp8e4m3_vec(const at::Tensor& t, bool channelwise, c10::optional<at::Tensor> scale_opt) {
+  if (channelwise) {
+    return _quantize_fp8e4m3_bf16_per_tensor_no_scale(t);
+  } else {
+    assert(scale_opt.has_value());
+    return _quantize_fp8e4m3_bf16_per_tensor_with_scale(t, scale_opt.value());
+  }
+}
+
 at::Tensor fp8_scaled_mm_with_quant(
     const at::Tensor& act,
     const std::optional<at::Tensor>& act_scales,
@@ -719,7 +949,10 @@ at::Tensor fp8_scaled_mm_with_quant(
     const at::Tensor& weight_scales,
     const std::optional<at::Tensor>& bias,
     at::ScalarType output_dtype) {
-  std::tuple<at::Tensor, at::Tensor> quant_act = _quantize_fp8e4m3(act, channelwise, act_scales);
+  // TODO: refine here to use tensor ptr and in below dispatch api.
+  std::tuple<at::Tensor, at::Tensor> quant_act = act.scalar_type() == at::ScalarType::BFloat16
+                                                     ? _quantize_fp8e4m3_vec(act, channelwise, act_scales)
+                                                     : _quantize_fp8e4m3(act, channelwise, act_scales);
   auto input = std::get<0>(quant_act);
   auto input_scales = std::get<1>(quant_act);
   int64_t N = weight.dim() == 4 ? weight.size(0) * weight.size(-1) : weight.size(0);

--- a/sgl-kernel/csrc/cpu/gemm_fp8_w8a8.cpp
+++ b/sgl-kernel/csrc/cpu/gemm_fp8_w8a8.cpp
@@ -406,6 +406,25 @@ void _float8_linear_impl(
 
 }  // anonymous namespace
 
+
+template <bool cpublas_can_pack, int64_t N, int act_quant_mode, int wei_quant_mode>
+void tinygemm_kernel2(
+    float* C,
+    const at::Float8_e4m3fn* A,
+    const float* scales_a,
+    const at::Float8_e4m3fn* B,
+    const float* scales_b,
+    int64_t M,
+    int64_t K,
+    int64_t lda,
+    int64_t ldc,
+    int64_t ldsa,
+    float* ukernel_buf,
+    at::BFloat16* dqA_buf,
+    at::BFloat16* dqB_buf) {
+
+    return _micro_gemm<cpublas_can_pack, N, act_quant_mode, wei_quant_mode>(C, A, scales_a, B, scales_b, M, K, lda, ldc, ldsa, ukernel_buf,dqA_buf, dqB_buf );
+    }
 /*
 return: packed_weight, packed_scales
 */

--- a/sgl-kernel/csrc/cpu/moe.cpp
+++ b/sgl-kernel/csrc/cpu/moe.cpp
@@ -951,6 +951,7 @@ at::Tensor fused_experts_cpu(
     bool inplace,
     bool use_int8_w8a8,
     bool use_fp8_w8a16,
+    bool use_fp8_w8a8,
     const std::optional<at::Tensor>& w1_scale,
     const std::optional<at::Tensor>& w2_scale,
     const std::optional<std::vector<int64_t>> block_size,
@@ -1065,7 +1066,7 @@ at::Tensor fused_experts_cpu(
   if (use_int8_w8a8) {
     buffer_size_nbytes += std::max(M * K, M * topk * N) + M * topk * sizeof(float);
   }
-  if (use_fp8_w8a16) {
+  if (use_fp8_w8a16 || use_fp8_w8a8 ) {
     buffer_size_nbytes += M * topk * 2 * N * 2 + num_threads * MAX_CACHE_BLOCK_SIZE * BLOCK_N * std::max(K, N) * 2;
   }
 
@@ -1128,6 +1129,40 @@ at::Tensor fused_experts_cpu(
           hidden_states.data_ptr<scalar_t>(),
           packed_w1.data_ptr<at::Float8_e4m3fn>(),
           packed_w2.data_ptr<at::Float8_e4m3fn>(),
+          w1s.data_ptr<float>(),
+          w2s.data_ptr<float>(),
+          block_size_N,
+          block_size_K,
+          topk_weights_.data_ptr<float>(),
+          sorted_ids,
+          expert_ids,
+          offsets,
+          M,
+          N,
+          K,
+          E,
+          topk,
+          num_tokens_post_pad);
+    } else if (use_fp8_w8a8) {
+      // here we just ignore C_tmp as it is not used
+      at::Float8_e4m3fn* __restrict__ A_tmp = (at::Float8_e4m3fn*)((void*)(intermediate_cache2 + M * topk * K));
+      float* __restrict__ C_tmp = (float*)((void*)(A_tmp + num_threads * BLOCK_M * K));
+      scalar_t* __restrict__ intermediate_cache0 = (scalar_t*)((void*)(C_tmp + num_threads * 2 * BLOCK_M * BLOCK_N));
+      scalar_t* __restrict__ B_tmp = (scalar_t*)((void*)(intermediate_cache0 + M * topk * 2 * N));
+      auto a1s = a1_scale.value();
+      CHECK_MOE_SCALES_FP8(1, 2);
+      fused_experts_fp8_a8_kernel_impl(
+          out_hidden_states.data_ptr<scalar_t>(),
+          intermediate_cache0,
+          intermediate_cache1,
+          intermediate_cache2,
+          A_tmp,
+          B_tmp,
+          C_tmp,
+          hidden_states.data_ptr<at::Float8_e4m3fn>(),
+          packed_w1.data_ptr<at::Float8_e4m3fn>(),
+          packed_w2.data_ptr<at::Float8_e4m3fn>(),
+          a1s.data_ptr<float>(),
           w1s.data_ptr<float>(),
           w2s.data_ptr<float>(),
           block_size_N,

--- a/sgl-kernel/csrc/cpu/moe.cpp
+++ b/sgl-kernel/csrc/cpu/moe.cpp
@@ -930,11 +930,11 @@ static inline void check_moe_scales(
   auto w2s = w2_scale.value();                                \
   auto block_size_val = block_size.value();                   \
   int64_t block_size_N = block_size_val[0];                   \
-  int64_t block_size_K = block_size_val[1];                   \
-  TORCH_CHECK(w1s.size(DIM0) == div_up(2 * N, block_size_N)); \
-  TORCH_CHECK(w1s.size(DIM1) == div_up(K, block_size_K));     \
-  TORCH_CHECK(w2s.size(DIM0) == div_up(K, block_size_N));     \
-  TORCH_CHECK(w2s.size(DIM1) == div_up(N, block_size_K))
+  int64_t block_size_K = block_size_val[1];                   
+  // TORCH_CHECK(w1s.size(DIM0) == div_up(2 * N, block_size_N)); \
+  // TORCH_CHECK(w1s.size(DIM1) == div_up(K, block_size_K));     \
+  // TORCH_CHECK(w2s.size(DIM0) == div_up(K, block_size_N));     \
+  // TORCH_CHECK(w2s.size(DIM1) == div_up(N, block_size_K))
 
 // hidden_states: [M, K]
 // w1: [E, 2N, K]
@@ -966,14 +966,19 @@ at::Tensor fused_experts_cpu(
 
   constexpr int64_t BLOCK_M = block_size_m();
   constexpr int64_t BLOCK_N = block_size_n();
+  auto st_ = hidden_states.scalar_type();
+  if(use_fp8_w8a8){
+    st_ = at::kBFloat16;
+  }
+  const auto st = st_;
 
-  const auto st = hidden_states.scalar_type();
-  CHECK_INPUT(hidden_states);
-  CHECK_INPUT(w1);
+
+  // CHECK_INPUT(hidden_states);
+  // CHECK_INPUT(w1);
   CHECK_INPUT(w2);
   CHECK_EQ(topk_weights.sizes(), topk_ids.sizes());
   CHECK_DIM(2, hidden_states);
-  CHECK_DIM(3, w1);
+  // CHECK_DIM(3, w1);
   CHECK_DIM(3, w2);
   CHECK_DIM(2, topk_weights);
   CHECK_DIM(2, topk_ids);
@@ -988,7 +993,7 @@ at::Tensor fused_experts_cpu(
 
   int64_t M = hidden_states.size(0);
   int64_t K = hidden_states.size(1);
-  int64_t N = w1.size(1) / 2;
+  int64_t N = w2.size(2);
   int64_t E = w1.size(0);
   int64_t topk = topk_weights_.size(1);
 
@@ -999,13 +1004,13 @@ at::Tensor fused_experts_cpu(
   // check weight shapes
   CHECK_EQ(w2.size(0), E);
   CHECK_EQ(w2.size(1), K);
-  CHECK_EQ(packed_w1.size(2), packed_K);
+  // CHECK_EQ(packed_w1.size(2), packed_K);
   CHECK_EQ(packed_w2.size(2), packed_N);
 
   // check scales
   check_moe_scales(use_int8_w8a8, use_fp8_w8a16, w1_scale, w2_scale, block_size, a1_scale, a2_scale);
 
-  at::Tensor out_hidden_states = inplace ? hidden_states : at::empty_like(hidden_states);
+  at::Tensor out_hidden_states = inplace ? hidden_states : at::empty_like(hidden_states).to(at::kBFloat16);
 
   // NB: worst case is each expert holds a block with remainder of 1
   //   1. sorted_ids : [M * topk + E * (BLOCK_M - 1)]
@@ -1060,7 +1065,7 @@ at::Tensor fused_experts_cpu(
   //   8. B_tmp : [T, MAX_CACHE_BLOCK_SIZE, BLOCK_N, std::max(K, N)]
   //
   int64_t buffer_size_nbytes = M * topk * N * 2 + M * topk * K * 2 +
-                               num_threads * BLOCK_M * K * (use_int8_w8a8 ? 1 : 2) +
+                               num_threads * BLOCK_M * K * (use_int8_w8a8 || use_fp8_w8a8 ? 1 : 2) +
                                num_threads * 2 * BLOCK_M * BLOCK_N * sizeof(float);
 
   if (use_int8_w8a8) {
@@ -1255,7 +1260,7 @@ at::Tensor shared_expert_cpu(
 
   // check weight shapes
   CHECK_EQ(w2.size(0), K);
-  CHECK_EQ(packed_w1.size(1), packed_K);
+  // CHECK_EQ(packed_w1.size(1), packed_K);
   CHECK_EQ(packed_w2.size(1), packed_N);
 
   // check scales

--- a/sgl-kernel/csrc/cpu/moe.cpp
+++ b/sgl-kernel/csrc/cpu/moe.cpp
@@ -925,16 +925,16 @@ static inline void check_moe_scales(
   }
 }
 
-#define CHECK_MOE_SCALES_FP8(DIM0, DIM1)                      \
-  auto w1s = w1_scale.value();                                \
-  auto w2s = w2_scale.value();                                \
-  auto block_size_val = block_size.value();                   \
-  int64_t block_size_N = block_size_val[0];                   \
-  int64_t block_size_K = block_size_val[1];                   
-  // TORCH_CHECK(w1s.size(DIM0) == div_up(2 * N, block_size_N)); \
-  // TORCH_CHECK(w1s.size(DIM1) == div_up(K, block_size_K));     \
-  // TORCH_CHECK(w2s.size(DIM0) == div_up(K, block_size_N));     \
-  // TORCH_CHECK(w2s.size(DIM1) == div_up(N, block_size_K))
+#define CHECK_MOE_SCALES_FP8(DIM0, DIM1)    \
+  auto w1s = w1_scale.value();              \
+  auto w2s = w2_scale.value();              \
+  auto block_size_val = block_size.value(); \
+  int64_t block_size_N = block_size_val[0]; \
+  int64_t block_size_K = block_size_val[1];
+// TORCH_CHECK(w1s.size(DIM0) == div_up(2 * N, block_size_N)); \
+// TORCH_CHECK(w1s.size(DIM1) == div_up(K, block_size_K));     \
+// TORCH_CHECK(w2s.size(DIM0) == div_up(K, block_size_N));     \
+// TORCH_CHECK(w2s.size(DIM1) == div_up(N, block_size_K))
 
 // hidden_states: [M, K]
 // w1: [E, 2N, K]
@@ -967,11 +967,10 @@ at::Tensor fused_experts_cpu(
   constexpr int64_t BLOCK_M = block_size_m();
   constexpr int64_t BLOCK_N = block_size_n();
   auto st_ = hidden_states.scalar_type();
-  if(use_fp8_w8a8){
+  if (use_fp8_w8a8) {
     st_ = at::kBFloat16;
   }
   const auto st = st_;
-
 
   // CHECK_INPUT(hidden_states);
   // CHECK_INPUT(w1);
@@ -1060,10 +1059,11 @@ at::Tensor fused_experts_cpu(
   //   5. Aq_tmp : [M, K] or [M * topk, N]
   //   6. As_tmp : [M * topk]
   //
-  // for fp8 w8a16:
+  // for fp8 w8a16 / fp8 w8a8:
   //   7. intermediate_cache0 : [M * topk, 2N]
   //   8. B_tmp : [T, MAX_CACHE_BLOCK_SIZE, BLOCK_N, std::max(K, N)]
-  //
+  // for fp8 w8a8:
+  //   9. ukernel buffer: [T, 2 * BLOCK_M * BLOCK_N]
   int64_t buffer_size_nbytes = M * topk * N * 2 + M * topk * K * 2 +
                                num_threads * BLOCK_M * K * (use_int8_w8a8 || use_fp8_w8a8 ? 1 : 2) +
                                num_threads * 2 * BLOCK_M * BLOCK_N * sizeof(float);
@@ -1071,8 +1071,11 @@ at::Tensor fused_experts_cpu(
   if (use_int8_w8a8) {
     buffer_size_nbytes += std::max(M * K, M * topk * N) + M * topk * sizeof(float);
   }
-  if (use_fp8_w8a16 || use_fp8_w8a8 ) {
+  if (use_fp8_w8a16 || use_fp8_w8a8) {
     buffer_size_nbytes += M * topk * 2 * N * 2 + num_threads * MAX_CACHE_BLOCK_SIZE * BLOCK_N * std::max(K, N) * 2;
+  }
+  if (use_fp8_w8a8) {
+    buffer_size_nbytes += num_threads * 2 * BLOCK_M * BLOCK_N * sizeof(float);
   }
 
   auto buffer2 = at::empty({buffer_size_nbytes}, hidden_states.options().dtype(at::kChar));
@@ -1154,6 +1157,8 @@ at::Tensor fused_experts_cpu(
       float* __restrict__ C_tmp = (float*)((void*)(A_tmp + num_threads * BLOCK_M * K));
       scalar_t* __restrict__ intermediate_cache0 = (scalar_t*)((void*)(C_tmp + num_threads * 2 * BLOCK_M * BLOCK_N));
       scalar_t* __restrict__ B_tmp = (scalar_t*)((void*)(intermediate_cache0 + M * topk * 2 * N));
+      float* __restrict__ Ukernel_tmp =
+          (float*)((void*)(B_tmp + num_threads * MAX_CACHE_BLOCK_SIZE * BLOCK_N * std::max(K, N)));
       auto a1s = a1_scale.value();
       CHECK_MOE_SCALES_FP8(1, 2);
       fused_experts_fp8_a8_kernel_impl(
@@ -1164,6 +1169,7 @@ at::Tensor fused_experts_cpu(
           A_tmp,
           B_tmp,
           C_tmp,
+          Ukernel_tmp,
           hidden_states.data_ptr<at::Float8_e4m3fn>(),
           packed_w1.data_ptr<at::Float8_e4m3fn>(),
           packed_w2.data_ptr<at::Float8_e4m3fn>(),

--- a/sgl-kernel/csrc/cpu/moe_fp8_w8a8.cpp
+++ b/sgl-kernel/csrc/cpu/moe_fp8_w8a8.cpp
@@ -1,0 +1,467 @@
+#include "common.h"
+#include "gemm.h"
+#include "vec.h"
+#include <c10/util/Unroll.h>
+namespace {
+
+template <typename scalar_t>
+inline void copy_stub(scalar_t* __restrict__ out, const scalar_t* __restrict__ input, int64_t size) {
+  using Vec = at::vec::Vectorized<scalar_t>;
+// no remainder
+#pragma GCC unroll 4
+  for (int64_t d = 0; d < size; d += Vec::size()) {
+    Vec data = Vec::loadu(input + d);
+    data.store(out + d);
+  }
+}
+
+template <typename scalar_t>
+inline void copy_mul_stub(scalar_t* __restrict__ out, const scalar_t* __restrict__ input, float weight, int64_t size) {
+  using bVec = at::vec::Vectorized<scalar_t>;
+  using fVec = at::vec::Vectorized<float>;
+  constexpr int kVecSize = bVec::size();
+  const fVec weight_vec = fVec(weight);
+  int64_t d;
+#pragma GCC unroll 4
+  for (d = 0; d <= size - kVecSize; d += kVecSize) {
+    bVec x = bVec::loadu(input + d);
+    fVec x0, x1;
+    std::tie(x0, x1) = at::vec::convert_to_float(x);
+    x0 = x0 * weight_vec;
+    x1 = x1 * weight_vec;
+    bVec out_vec = convert_from_float_ext<scalar_t>(x0, x1);
+    out_vec.store(out + d);
+  }
+  for (; d < size; ++d) {
+    out[d] = static_cast<scalar_t>(input[d] * weight);
+  }
+}
+
+// acc from [topk, K] to [K]
+template <typename scalar_t>
+inline void sum_stub(scalar_t* __restrict__ out, const scalar_t* __restrict__ input, int64_t topk, int64_t K) {
+  using bVec = at::vec::Vectorized<scalar_t>;
+  using fVec = at::vec::Vectorized<float>;
+  constexpr int kVecSize = bVec::size();
+  if (topk == 1) {
+    // do copy for topk = 1
+    copy_stub(out, input, K);
+  } else {
+    // do sum for topk != 1
+    int64_t d;
+#pragma GCC unroll 4
+    for (d = 0; d <= K - kVecSize; d += kVecSize) {
+      fVec sum_fvec0 = fVec(0.f);
+      fVec sum_fvec1 = fVec(0.f);
+      for (int t = 0; t < topk; ++t) {
+        bVec x_bvec = bVec::loadu(input + t * K + d);
+        fVec x_fvec0, x_fvec1;
+        std::tie(x_fvec0, x_fvec1) = at::vec::convert_to_float(x_bvec);
+
+        sum_fvec0 += x_fvec0;
+        sum_fvec1 += x_fvec1;
+      }
+      bVec out_bvec = convert_from_float_ext<scalar_t>(sum_fvec0, sum_fvec1);
+      out_bvec.store(out + d);
+    }
+    for (; d < K; ++d) {
+      float sum_val = 0.f;
+      for (int t = 0; t < topk; ++t) {
+        sum_val += static_cast<float>(input[t * K + d]);
+      }
+      out[d] = static_cast<scalar_t>(sum_val);
+    }
+  }
+}
+
+// out = input + input2 * scale
+template <typename scalar_t>
+inline void add_mul_stub(
+    scalar_t* __restrict__ out,
+    const scalar_t* __restrict__ input,
+    const scalar_t* __restrict__ input2,
+    float scale,
+    int64_t size) {
+  using bVec = at::vec::Vectorized<scalar_t>;
+  using fVec = at::vec::Vectorized<float>;
+  constexpr int kVecSize = bVec::size();
+  const fVec s_vec = fVec(scale);
+
+  int64_t d;
+#pragma GCC unroll 4
+  for (d = 0; d <= size - kVecSize; d += kVecSize) {
+    bVec x_bvec = bVec::loadu(input + d);
+    fVec x0, x1;
+    std::tie(x0, x1) = at::vec::convert_to_float(x_bvec);
+
+    bVec y_bvec = bVec::loadu(input2 + d);
+    fVec y0, y1;
+    std::tie(y0, y1) = at::vec::convert_to_float(y_bvec);
+
+    x0 = x0 + y0 * s_vec;
+    x1 = x1 + y1 * s_vec;
+    bVec out_vec = convert_from_float_ext<scalar_t>(x0, x1);
+    out_vec.store(out + d);
+  }
+  for (; d < size; ++d) {
+    out[d] = static_cast<scalar_t>(input[d] + float(input2[d]) * scale);
+  }
+}
+
+template <typename scalar_t>
+inline void silu_and_mul_stub(
+    scalar_t* __restrict__ out, const scalar_t* __restrict__ input, const scalar_t* __restrict__ input2, int64_t size) {
+  using bVec = at::vec::Vectorized<scalar_t>;
+  using fVec = at::vec::Vectorized<float>;
+  const fVec one = fVec(1.f);
+
+  // no remainder
+#pragma GCC unroll 4
+  for (int64_t d = 0; d < size; d += bVec::size()) {
+    bVec x = bVec::loadu(input + d);
+    fVec x0, x1;
+    std::tie(x0, x1) = at::vec::convert_to_float(x);
+    bVec y = bVec::loadu(input2 + d);
+    fVec y0, y1;
+    std::tie(y0, y1) = at::vec::convert_to_float(y);
+    x0 = x0 / (one + x0.neg().exp_u20());
+    x1 = x1 / (one + x1.neg().exp_u20());
+    x0 = x0 * y0;
+    x1 = x1 * y1;
+    bVec out_vec = convert_from_float_ext<scalar_t>(x0, x1);
+    out_vec.store(out + d);
+  }
+}
+
+#define PER_TENSOR 1
+#define PER_ROW 2
+#define PER_GROUP 3
+
+// Store result to output buffer with dtype conversion
+// If act/wei are per_row or per_tensor quantized, apply scales
+// If bias is not null, add bias
+template <typename out_dtype, int64_t N, int act_quant_mode, int wei_quant_mode>
+inline void store_out(
+    const float* y_buf,
+    out_dtype* c_ptr,
+    int64_t M,
+    int64_t lda,
+    const float* scales_a,
+    const float* scales_b,
+    const float* bias) {
+  float a_scale = 1.0, b_scale = 1.0;
+  __m512 va_scale, vb_scale;
+  if constexpr (act_quant_mode == PER_TENSOR) {
+    a_scale = *scales_a;
+  }
+  if constexpr (wei_quant_mode == PER_TENSOR) {
+    b_scale = *scales_b;
+    vb_scale = _mm512_set1_ps(b_scale);
+  }
+  for (int i = 0; i < M; ++i) {
+    if constexpr (act_quant_mode == PER_ROW) {
+      a_scale = *(scales_a + i);
+    }
+    if constexpr (act_quant_mode != PER_GROUP) {
+      va_scale = _mm512_set1_ps(a_scale);
+    }
+    constexpr int N_UNROLL = N / 16;
+    c10::ForcedUnroll<N_UNROLL>{}([&](auto idx) {
+      constexpr int j = idx * 16;
+      __m512 y_vec = _mm512_loadu_ps(y_buf + i * N + j);
+      __m512 bias_vec = bias ? _mm512_loadu_ps(bias + j) : _mm512_setzero_ps();
+      if constexpr (act_quant_mode != PER_GROUP) {
+        y_vec = _mm512_mul_ps(y_vec, va_scale);
+      }
+      if constexpr (wei_quant_mode == PER_ROW) {
+        vb_scale = _mm512_loadu_ps(scales_b + j);
+      }
+      if constexpr (wei_quant_mode != PER_GROUP) {
+        y_vec = _mm512_mul_ps(y_vec, vb_scale);
+      }
+      y_vec = _mm512_add_ps(y_vec, bias_vec);
+      if constexpr (std::is_same<out_dtype, float>::value) {
+        _mm512_storeu_ps(c_ptr + i * lda + j, y_vec);
+      } else if constexpr (std::is_same<out_dtype, at::BFloat16>::value) {
+        __m256i y_bf16_vec = at::vec::cvtfp32_bf16(y_vec);
+        _mm256_storeu_si256(reinterpret_cast<__m256i*>(c_ptr + i * lda + j), y_bf16_vec);
+      } else if constexpr (std::is_same<out_dtype, at::Half>::value) {
+        __m256i y_fp16_vec = at::vec::cvtfp32_fp16(y_vec);
+        _mm256_storeu_si256(reinterpret_cast<__m256i*>(c_ptr + i * lda + j), y_fp16_vec);
+      } else {
+        TORCH_CHECK(false, "Unsupported output dtype");
+      }
+    });
+    constexpr int tail_start = N / 16 * 16;
+    for (int j = tail_start; j < N; ++j) {
+      if constexpr (wei_quant_mode == PER_ROW) {
+        b_scale = scales_b[j];
+      }
+      c_ptr[i * lda + j] = static_cast<out_dtype>(y_buf[i * N + j] * a_scale * b_scale);
+    }
+  }  // for M
+}
+
+}  // anonymous namespace
+
+
+
+// act : per channel quant
+// weight: per block_N x block_K quant
+template <typename scalar_t>
+void fused_experts_fp8_a8_kernel_impl(
+    scalar_t* __restrict__ output,
+    scalar_t* __restrict__ ic0,
+    scalar_t* __restrict__ ic1,
+    scalar_t* __restrict__ ic2,
+    at::Float8_e4m3fn* __restrict__ A_tmp,
+    scalar_t* __restrict__ B_tmp,
+    float* __restrict__ C_tmp,
+    const at::Float8_e4m3fn* __restrict__ input,
+    const at::Float8_e4m3fn* __restrict__ packed_w1,
+    const at::Float8_e4m3fn* __restrict__ packed_w2,
+    const float* __restrict__ As,
+    const float* __restrict__ w1s,
+    const float* __restrict__ w2s,
+    int64_t block_size_N,
+    int64_t block_size_K,
+    const float* __restrict__ topk_weights,
+    const int32_t* __restrict__ sorted_ids,
+    const int32_t* __restrict__ expert_ids,
+    const int32_t* __restrict__ offsets,
+    int64_t M,
+    int64_t N,
+    int64_t K,
+    int64_t E,
+    int64_t topk,
+    int64_t num_tokens_post_pad) {
+
+  //   1. intermediate_cache1 : [M * topk, N]
+  //   2. intermediate_cache2 : [M * topk, K]
+  //   3. A_tmp : [T, BLOCK_M * K]
+  //   4. C_tmp : [T, 2 * BLOCK_M * BLOCK_N]
+  //   7. intermediate_cache0 : [M * topk, 2N]
+  //   8. B_tmp : [T, MAX_CACHE_BLOCK_SIZE, BLOCK_N, std::max(K, N)]
+
+
+  constexpr int64_t BLOCK_M = block_size_m();
+  constexpr int64_t BLOCK_N = block_size_n();
+  int64_t B_tmp_size_per_thread = MAX_CACHE_BLOCK_SIZE * BLOCK_N * std::max(K, N);
+  // stage 1: intermediate_cache0 = hidden_states @ w1
+  const int64_t MB = div_up(num_tokens_post_pad, BLOCK_M);
+  const int64_t NB = div_up(N, BLOCK_N);
+  const int64_t KB = K/BLOCK_K; // use div_up
+  int64_t scale_size_N = div_up(2 * N, block_size_N);
+  int64_t scale_size_K = div_up(K, block_size_K);
+  int64_t blocks_n_per_group = block_size_N / BLOCK_N; // use div_up
+  int64_t num_groups = div_up(K, block_size_K);  // G, block_size_K is group size
+  int64_t blocks_k_per_group = block_size_K / BLOCK_K; // use div_up
+  const int64_t stride_e = 2 * N * K;
+  const int64_t stride_n = K;
+  const bool use_brgemm = true;
+
+  int64_t block_size = BLOCK_M * BLOCK_N;
+  int64_t num_thread = at::get_num_threads();
+  at::Tensor y_buffer = at::empty({num_thread, block_size});
+  // buffer for brgemm output in float32
+  int64_t buffer_size = block_size * 2;  // float32 = bfloat16 * 2
+  at::Tensor micro_gemm_buffer = at::empty({num_thread, buffer_size}).to(at::kBFloat16);
+  at::Tensor micro_gemm_buffer2 = at::empty({num_thread, buffer_size}).to(at::kBFloat16);
+  // weight shape = [E, (2) Nc, Kc, block_k, block_n]
+  // scales shape = [E, Nc, G, block_n]
+  at::parallel_for(0, MB * NB, 1, [&](int64_t begin, int64_t end) {
+    // get local pointers
+    int tid = get_thread_num();
+    at::Float8_e4m3fn* __restrict__ A = A_tmp + tid * BLOCK_M * K;
+    float*  __restrict__ C0 = C_tmp + tid * 2 * BLOCK_M * BLOCK_N;
+    float*  __restrict__ C1 = C0 + BLOCK_M * BLOCK_N;
+    alignas(64) float As_[BLOCK_M];
+    at::BFloat16* micro_gemm_buf = micro_gemm_buffer.data_ptr<at::BFloat16>() + at::get_thread_num() * buffer_size;
+    float* ukernel_buf = reinterpret_cast<float*>(micro_gemm_buf);
+
+    at::BFloat16* micro_gemm_buf2 = micro_gemm_buffer2.data_ptr<at::BFloat16>() + at::get_thread_num() * buffer_size;
+    float* ukernel_buf2 = reinterpret_cast<float*>(micro_gemm_buf2);
+    auto ldsa = num_groups; // act per group quant
+    for (int64_t i = begin; i < end; ++i) {
+      int64_t mb = i / NB;
+      int64_t nb = i % NB;
+      int64_t nb1 = nb + NB;
+      int64_t n_size = std::min(N - nb * BLOCK_N, BLOCK_N);
+
+      // B shape [K, n_size] in vnni format
+      int32_t expert_id = expert_ids[mb];
+      const at::Float8_e4m3fn* __restrict__ B = packed_w1 + expert_id * stride_e;
+      const float* __restrict__ Bs = w1s + expert_id * (num_groups) * (2 * N);
+      // 1.a load A
+      const int32_t* A_ids = sorted_ids + mb * BLOCK_M;
+      int64_t m_size = offsets[mb + 1] - offsets[mb];
+
+      for (int64_t m = 0; m < m_size; ++m) {
+        int32_t index = A_ids[m] / topk;
+        copy_stub(A + m * K, input + index * K, K);
+        As_[m] = As[index];
+      }
+
+      const int64_t offset = offsets[mb];
+
+      for (int kci = 0; kci < KB; ++kci) {
+        // auto scales_a = As + kci / block_per_group;
+        tinygemm_kernel2<true, BLOCK_N, 2, 3>(
+          /* C */ C0,
+          /* A */ A + kci * BLOCK_K,
+          /* scales_a */ As_,
+          /* B */ B + (nb * KB + kci) * BLOCK_K * BLOCK_N,
+          /* scales_b */ Bs + nb * BLOCK_N * num_groups + kci / blocks_k_per_group * BLOCK_N /*scales_b*/,
+          /* M */ m_size,
+          /* K */ BLOCK_K,
+          /* lda */ K,
+          /* ldc */ BLOCK_N,
+          /* ldsa */ ldsa,
+          /* ukernel_buf */ ukernel_buf,
+          /* dqA_buf */ nullptr,
+          /* dqB_buf */ nullptr);
+      }
+      store_out<scalar_t, BLOCK_N, 2, 3>(
+        C0, ic0 + mb * BLOCK_M * N + nb * BLOCK_N, m_size, N /*lda*/, As_, Bs + nb * BLOCK_N, nullptr /*bias data*/);
+
+      for (int kci = 0; kci < KB; ++kci) {
+        // auto scales_a = As + kci / block_per_group;
+        tinygemm_kernel2<true, BLOCK_N, 2, 3>(
+          /* C */ C1,
+          /* A */ A + kci * BLOCK_K,
+          /* scales_a */ As_,
+          /* B */ B + (nb1 * KB + kci) * BLOCK_K * BLOCK_N,
+          /* scales_b */ Bs + nb1 * BLOCK_N * num_groups + kci / blocks_k_per_group * BLOCK_N /*scales_b*/,
+          /* M */ m_size,
+          /* K */ BLOCK_K,
+          /* lda */ K,
+          /* ldc */ BLOCK_N,
+          /* ldsa */ ldsa,
+          /* ukernel_buf */ ukernel_buf2,
+          /* dqA_buf */ nullptr,
+          /* dqB_buf */ nullptr);
+      }
+      store_out<scalar_t, BLOCK_N, 2, 3>(
+        C1, ic0 + mb * BLOCK_M * N + nb1 * BLOCK_N, m_size, N /*lda*/, As_, Bs + nb1 * BLOCK_N, nullptr /*bias data*/);
+
+    }
+    if (use_brgemm) {
+      at::native::cpublas::brgemm_release();
+    }
+  });
+
+  // stage 1.5: intermediate_cache1 = silu(intermediate_cache0)
+  at::parallel_for(0, M * topk, 0, [&](int64_t begin, int64_t end) {
+    for (int64_t m = begin; m < end; ++m) {
+      silu_and_mul_stub(ic1 + m * N, ic0 + m * 2 * N, ic0 + m * 2 * N + N, N);
+    }
+  });
+
+  // stage 2: intermediate_cache2 = intermediate_cache1 @ w2
+  //   w2 : [E, K, N] as [E, OC, IC]
+  const int64_t OC = K;  // rename K as OC
+  const int64_t IC = N;  // rename N as IC
+  const int64_t MB2 = MB;
+  const int64_t NB2 = div_up(OC, BLOCK_N);
+  scale_size_N = div_up(K, block_size_N);
+  scale_size_K = div_up(N, block_size_K);
+  const int64_t stride_e2 = OC * IC;
+  const int64_t stride_oc = IC;
+
+  // parallel on [MB2, NB2]
+  parallel_2d(MB2, NB2, [&](int64_t mb0, int64_t mb1, int64_t nb0, int64_t nb1) {
+    int tid = get_thread_num();
+    alignas(64) scalar_t C[BLOCK_M * BLOCK_K];
+
+    loop_2d<at::Float8_e4m3fn>(mb0, mb1, nb0, nb1, BLOCK_N * IC, [&](int64_t mb, int64_t nb, int64_t nb_offset) {
+      int64_t m_size = offsets[mb + 1] - offsets[mb];
+      int64_t n_size = std::min(OC - nb * BLOCK_N, BLOCK_N);
+
+      // A ptr from ic1 of [M * topk, N] in sorted order
+      // so as to avoid copy A to tmp buffer again
+      const scalar_t* __restrict__ A = ic1 + offsets[mb] * N;
+      const int32_t* A_ids = sorted_ids + mb * BLOCK_M;
+
+      // B shape [IC, n_size] in vnni format
+      int32_t expert_id = expert_ids[mb];
+      const at::Float8_e4m3fn* __restrict__ B = packed_w2 + expert_id * stride_e2 + nb * BLOCK_N * stride_oc;
+      const float* __restrict__ Bs =
+          w2s + expert_id * scale_size_N * scale_size_K + (nb / blocks_n_per_group) * scale_size_K;
+
+      // do unpacking for the first row or a new expert
+      int32_t pre_expert_id = mb == 0 ? -1 : expert_ids[mb - 1];
+      bool do_unpack = (mb == mb0) || (expert_id != pre_expert_id);
+
+      tinygemm_kernel<scalar_t>(
+          /*   A            */ A,
+          /*   B            */ B,
+          /*   C            */ C,
+          /*   Btmp         */ B_tmp + tid * B_tmp_size_per_thread + nb_offset * BLOCK_N * IC,
+          /*   Ctmp         */ C_tmp + tid * 2 * BLOCK_M * BLOCK_N,
+          /*   scale        */ Bs,
+          /*   M            */ m_size,
+          /*   N            */ n_size,
+          /*   K            */ IC,
+          /*   lda          */ IC,
+          /*   ldb          */ n_size,
+          /*   ldc          */ BLOCK_N,
+          /*   brg          */ use_brgemm,
+          /*   block_size_K */ block_size_K,
+          /*   do_unpack    */ do_unpack);
+
+      // 2.b copy from C to ic2 in original order
+      //   and also mul topk_weights in float32
+      for (int64_t m = 0; m < m_size; ++m) {
+        int32_t index = A_ids[m];
+        float weight = topk_weights[index];
+        copy_mul_stub(ic2 + index * K + nb * BLOCK_N, C + m * BLOCK_N, weight, n_size);
+      }
+    });
+
+    if (use_brgemm) {
+      at::native::cpublas::brgemm_release();
+    }
+  });
+
+  // stage 3: out = intermediate_cache2.sum(dim=1)
+  //   from [M, topk, K] to [M, K]
+  at::parallel_for(0, M, 0, [&](int64_t begin, int64_t end) {
+    for (int64_t m = begin; m < end; ++m) {
+      sum_stub(output + m * K, ic2 + m * topk * K, topk, K);
+    }
+  });
+}
+
+#define INSTANTIATE_MOE_FP8_A8_TEMPLATE(TYPE)             \
+  template void fused_experts_fp8_a8_kernel_impl<TYPE>(   \
+      TYPE* __restrict__ output,                       \
+      TYPE* __restrict__ ic0,                          \
+      TYPE* __restrict__ ic1,                          \
+      TYPE* __restrict__ ic2,                          \
+      at::Float8_e4m3fn* __restrict__ A_tmp,                        \
+      TYPE* __restrict__ B_tmp,                        \
+      float* __restrict__ C_tmp,                       \
+      const at::Float8_e4m3fn* __restrict__ input,                  \
+      const at::Float8_e4m3fn* __restrict__ packed_w1, \
+      const at::Float8_e4m3fn* __restrict__ packed_w2, \
+      const float* __restrict__ As,                   \
+      const float* __restrict__ w1s,                   \
+      const float* __restrict__ w2s,                   \
+      int64_t block_size_N,                            \
+      int64_t block_size_K,                            \
+      const float* __restrict__ topk_weights,          \
+      const int32_t* __restrict__ sorted_ids,          \
+      const int32_t* __restrict__ expert_ids,          \
+      const int32_t* __restrict__ offsets,             \
+      int64_t M,                                       \
+      int64_t N,                                       \
+      int64_t K,                                       \
+      int64_t E,                                       \
+      int64_t topk,                                    \
+      int64_t num_tokens_post_pad)
+
+
+
+INSTANTIATE_MOE_FP8_A8_TEMPLATE(at::BFloat16);
+INSTANTIATE_MOE_FP8_A8_TEMPLATE(at::Half);
+

--- a/sgl-kernel/csrc/cpu/moe_fp8_w8a8.cpp
+++ b/sgl-kernel/csrc/cpu/moe_fp8_w8a8.cpp
@@ -15,6 +15,15 @@ inline void copy_stub(scalar_t* __restrict__ out, const scalar_t* __restrict__ i
   }
 }
 
+inline void copy_stub2(at::Float8_e4m3fn* __restrict__ out, const at::Float8_e4m3fn* __restrict__ input, int64_t size) {
+// no remainder
+// #pragma GCC unroll 4
+  for (int64_t d = 0; d < size; d ++) {
+    out[d] = input[d];
+  }
+}
+
+
 template <typename scalar_t>
 inline void copy_mul_stub(scalar_t* __restrict__ out, const scalar_t* __restrict__ input, float weight, int64_t size) {
   using bVec = at::vec::Vectorized<scalar_t>;
@@ -243,7 +252,6 @@ void fused_experts_fp8_a8_kernel_impl(
   //   7. intermediate_cache0 : [M * topk, 2N]
   //   8. B_tmp : [T, MAX_CACHE_BLOCK_SIZE, BLOCK_N, std::max(K, N)]
 
-
   constexpr int64_t BLOCK_M = block_size_m();
   constexpr int64_t BLOCK_N = block_size_n();
   int64_t B_tmp_size_per_thread = MAX_CACHE_BLOCK_SIZE * BLOCK_N * std::max(K, N);
@@ -259,29 +267,30 @@ void fused_experts_fp8_a8_kernel_impl(
   const int64_t stride_e = 2 * N * K;
   const int64_t stride_n = K;
   const bool use_brgemm = true;
-
   int64_t block_size = BLOCK_M * BLOCK_N;
   int64_t num_thread = at::get_num_threads();
-  at::Tensor y_buffer = at::empty({num_thread, block_size});
   // buffer for brgemm output in float32
   int64_t buffer_size = block_size * 2;  // float32 = bfloat16 * 2
   at::Tensor micro_gemm_buffer = at::empty({num_thread, buffer_size}).to(at::kBFloat16);
   at::Tensor micro_gemm_buffer2 = at::empty({num_thread, buffer_size}).to(at::kBFloat16);
+  at::Tensor C0_ = at::empty({num_thread,BLOCK_M*BLOCK_N});
+  at::Tensor C1_ = at::empty({num_thread,BLOCK_M*BLOCK_N});
   // weight shape = [E, (2) Nc, Kc, block_k, block_n]
   // scales shape = [E, Nc, G, block_n]
   at::parallel_for(0, MB * NB, 1, [&](int64_t begin, int64_t end) {
     // get local pointers
     int tid = get_thread_num();
     at::Float8_e4m3fn* __restrict__ A = A_tmp + tid * BLOCK_M * K;
-    float*  __restrict__ C0 = C_tmp + tid * 2 * BLOCK_M * BLOCK_N;
-    float*  __restrict__ C1 = C0 + BLOCK_M * BLOCK_N;
+    float*  __restrict__ C0 = C0_.data_ptr<float>() + tid * BLOCK_M * BLOCK_N;
+    float*  __restrict__ C1 = C1_.data_ptr<float>() + tid * BLOCK_M * BLOCK_N;
+    // float*  __restrict__ C0 = C_tmp + tid * 2 * BLOCK_M * BLOCK_N;
+    // float*  __restrict__ C1 = C0 + BLOCK_M * BLOCK_N;
     alignas(64) float As_[BLOCK_M];
-    at::BFloat16* micro_gemm_buf = micro_gemm_buffer.data_ptr<at::BFloat16>() + at::get_thread_num() * buffer_size;
+    at::BFloat16* micro_gemm_buf = micro_gemm_buffer.data_ptr<at::BFloat16>() + tid * buffer_size;
+    at::BFloat16* micro_gemm_buf2 = micro_gemm_buffer2.data_ptr<at::BFloat16>() + tid * buffer_size;
     float* ukernel_buf = reinterpret_cast<float*>(micro_gemm_buf);
-
-    at::BFloat16* micro_gemm_buf2 = micro_gemm_buffer2.data_ptr<at::BFloat16>() + at::get_thread_num() * buffer_size;
     float* ukernel_buf2 = reinterpret_cast<float*>(micro_gemm_buf2);
-    auto ldsa = num_groups; // act per group quant
+    auto ldsa = 1;//num_groups; // act per PER_ROW quant
     for (int64_t i = begin; i < end; ++i) {
       int64_t mb = i / NB;
       int64_t nb = i % NB;
@@ -298,18 +307,19 @@ void fused_experts_fp8_a8_kernel_impl(
 
       for (int64_t m = 0; m < m_size; ++m) {
         int32_t index = A_ids[m] / topk;
-        copy_stub(A + m * K, input + index * K, K);
+        copy_stub2(A + m * K, input + index * K, K);
         As_[m] = As[index];
       }
-
+      // A shape [m_size, K]
       const int64_t offset = offsets[mb];
-
+      // ic0 + offset * 2 * N + nb * BLOCK_N,
+      zero_buffer(C0, BLOCK_M * BLOCK_N);
       for (int kci = 0; kci < KB; ++kci) {
         // auto scales_a = As + kci / block_per_group;
-        tinygemm_kernel2<true, BLOCK_N, 2, 3>(
+        tinygemm_kernel2(//<true, BLOCK_N, 2, 3>(
           /* C */ C0,
           /* A */ A + kci * BLOCK_K,
-          /* scales_a */ As_,
+          /* scales_a */ As_ + kci / blocks_k_per_group,
           /* B */ B + (nb * KB + kci) * BLOCK_K * BLOCK_N,
           /* scales_b */ Bs + nb * BLOCK_N * num_groups + kci / blocks_k_per_group * BLOCK_N /*scales_b*/,
           /* M */ m_size,
@@ -322,14 +332,14 @@ void fused_experts_fp8_a8_kernel_impl(
           /* dqB_buf */ nullptr);
       }
       store_out<scalar_t, BLOCK_N, 2, 3>(
-        C0, ic0 + mb * BLOCK_M * N + nb * BLOCK_N, m_size, N /*lda*/, As_, Bs + nb * BLOCK_N, nullptr /*bias data*/);
-
+        C0, ic0 + offset * 2 * N + nb * BLOCK_N, m_size, 2*N /*lda*/, As_, nullptr, nullptr /*bias data*/);
+      zero_buffer(C1, BLOCK_M * BLOCK_N);
       for (int kci = 0; kci < KB; ++kci) {
         // auto scales_a = As + kci / block_per_group;
-        tinygemm_kernel2<true, BLOCK_N, 2, 3>(
+        tinygemm_kernel2(//<true, BLOCK_N, 2, 3>(
           /* C */ C1,
           /* A */ A + kci * BLOCK_K,
-          /* scales_a */ As_,
+          /* scales_a */ As_ + kci / blocks_k_per_group,
           /* B */ B + (nb1 * KB + kci) * BLOCK_K * BLOCK_N,
           /* scales_b */ Bs + nb1 * BLOCK_N * num_groups + kci / blocks_k_per_group * BLOCK_N /*scales_b*/,
           /* M */ m_size,
@@ -342,8 +352,7 @@ void fused_experts_fp8_a8_kernel_impl(
           /* dqB_buf */ nullptr);
       }
       store_out<scalar_t, BLOCK_N, 2, 3>(
-        C1, ic0 + mb * BLOCK_M * N + nb1 * BLOCK_N, m_size, N /*lda*/, As_, Bs + nb1 * BLOCK_N, nullptr /*bias data*/);
-
+        C1, ic0 + offset * 2 * N + nb1 * BLOCK_N, m_size, 2*N /*lda*/, As_, nullptr, nullptr /*bias data*/);
     }
     if (use_brgemm) {
       at::native::cpublas::brgemm_release();

--- a/sgl-kernel/csrc/cpu/moe_fp8_w8a8.cpp
+++ b/sgl-kernel/csrc/cpu/moe_fp8_w8a8.cpp
@@ -1,7 +1,8 @@
+#include <c10/util/Unroll.h>
+
 #include "common.h"
 #include "gemm.h"
 #include "vec.h"
-#include <c10/util/Unroll.h>
 namespace {
 
 template <typename scalar_t>
@@ -16,13 +17,12 @@ inline void copy_stub(scalar_t* __restrict__ out, const scalar_t* __restrict__ i
 }
 
 inline void copy_stub2(at::Float8_e4m3fn* __restrict__ out, const at::Float8_e4m3fn* __restrict__ input, int64_t size) {
-// no remainder
-// #pragma GCC unroll 4
-  for (int64_t d = 0; d < size; d ++) {
+  // no remainder
+  // #pragma GCC unroll 4
+  for (int64_t d = 0; d < size; d++) {
     out[d] = input[d];
   }
 }
-
 
 template <typename scalar_t>
 inline void copy_mul_stub(scalar_t* __restrict__ out, const scalar_t* __restrict__ input, float weight, int64_t size) {
@@ -213,8 +213,6 @@ inline void store_out(
 
 }  // anonymous namespace
 
-
-
 // act : per channel quant
 // weight: per block_N x block_K quant
 template <typename scalar_t>
@@ -226,6 +224,7 @@ void fused_experts_fp8_a8_kernel_impl(
     at::Float8_e4m3fn* __restrict__ A_tmp,
     scalar_t* __restrict__ B_tmp,
     float* __restrict__ C_tmp,
+    float* __restrict__ Ukernel_tmp,
     const at::Float8_e4m3fn* __restrict__ input,
     const at::Float8_e4m3fn* __restrict__ packed_w1,
     const at::Float8_e4m3fn* __restrict__ packed_w2,
@@ -244,13 +243,13 @@ void fused_experts_fp8_a8_kernel_impl(
     int64_t E,
     int64_t topk,
     int64_t num_tokens_post_pad) {
-
   //   1. intermediate_cache1 : [M * topk, N]
   //   2. intermediate_cache2 : [M * topk, K]
   //   3. A_tmp : [T, BLOCK_M * K]
   //   4. C_tmp : [T, 2 * BLOCK_M * BLOCK_N]
   //   7. intermediate_cache0 : [M * topk, 2N]
   //   8. B_tmp : [T, MAX_CACHE_BLOCK_SIZE, BLOCK_N, std::max(K, N)]
+  //   9. ukernel buffer: [T, 2 * BLOCK_M * BLOCK_N]
 
   constexpr int64_t BLOCK_M = block_size_m();
   constexpr int64_t BLOCK_N = block_size_n();
@@ -258,39 +257,27 @@ void fused_experts_fp8_a8_kernel_impl(
   // stage 1: intermediate_cache0 = hidden_states @ w1
   const int64_t MB = div_up(num_tokens_post_pad, BLOCK_M);
   const int64_t NB = div_up(N, BLOCK_N);
-  const int64_t KB = K/BLOCK_K; // use div_up
+  const int64_t KB = K / BLOCK_K;  // use div_up
   int64_t scale_size_N = div_up(2 * N, block_size_N);
   int64_t scale_size_K = div_up(K, block_size_K);
-  int64_t blocks_n_per_group = block_size_N / BLOCK_N; // use div_up
-  int64_t num_groups = div_up(K, block_size_K);  // G, block_size_K is group size
-  int64_t blocks_k_per_group = block_size_K / BLOCK_K; // use div_up
+  int64_t blocks_n_per_group = block_size_N / BLOCK_N;  // use div_up
+  int64_t num_groups = div_up(K, block_size_K);         // G, block_size_K is group size
+  int64_t blocks_k_per_group = block_size_K / BLOCK_K;  // use div_up
   const int64_t stride_e = 2 * N * K;
   const int64_t stride_n = K;
-  const bool use_brgemm = true;
+  bool use_brgemm = true;
   int64_t block_size = BLOCK_M * BLOCK_N;
   int64_t num_thread = at::get_num_threads();
-  // buffer for brgemm output in float32
-  int64_t buffer_size = block_size * 2;  // float32 = bfloat16 * 2
-  at::Tensor micro_gemm_buffer = at::empty({num_thread, buffer_size}).to(at::kBFloat16);
-  at::Tensor micro_gemm_buffer2 = at::empty({num_thread, buffer_size}).to(at::kBFloat16);
-  at::Tensor C0_ = at::empty({num_thread,BLOCK_M*BLOCK_N});
-  at::Tensor C1_ = at::empty({num_thread,BLOCK_M*BLOCK_N});
-  // weight shape = [E, (2) Nc, Kc, block_k, block_n]
-  // scales shape = [E, Nc, G, block_n]
   at::parallel_for(0, MB * NB, 1, [&](int64_t begin, int64_t end) {
     // get local pointers
     int tid = get_thread_num();
     at::Float8_e4m3fn* __restrict__ A = A_tmp + tid * BLOCK_M * K;
-    float*  __restrict__ C0 = C0_.data_ptr<float>() + tid * BLOCK_M * BLOCK_N;
-    float*  __restrict__ C1 = C1_.data_ptr<float>() + tid * BLOCK_M * BLOCK_N;
-    // float*  __restrict__ C0 = C_tmp + tid * 2 * BLOCK_M * BLOCK_N;
-    // float*  __restrict__ C1 = C0 + BLOCK_M * BLOCK_N;
+    float* __restrict__ C0 = C_tmp + tid * 2 * BLOCK_M * BLOCK_N;
+    float* __restrict__ C1 = C0 + BLOCK_M * BLOCK_N;
     alignas(64) float As_[BLOCK_M];
-    at::BFloat16* micro_gemm_buf = micro_gemm_buffer.data_ptr<at::BFloat16>() + tid * buffer_size;
-    at::BFloat16* micro_gemm_buf2 = micro_gemm_buffer2.data_ptr<at::BFloat16>() + tid * buffer_size;
-    float* ukernel_buf = reinterpret_cast<float*>(micro_gemm_buf);
-    float* ukernel_buf2 = reinterpret_cast<float*>(micro_gemm_buf2);
-    auto ldsa = 1;//num_groups; // act per PER_ROW quant
+    float* __restrict__ ukernel_buf_1 = Ukernel_tmp + +tid * 2 * BLOCK_M * BLOCK_N;
+    float* __restrict__ ukernel_buf_2 = ukernel_buf_1 + BLOCK_M * BLOCK_N;
+    auto ldsa = 1;  // act per PER_ROW quant
     for (int64_t i = begin; i < end; ++i) {
       int64_t mb = i / NB;
       int64_t nb = i % NB;
@@ -315,44 +302,44 @@ void fused_experts_fp8_a8_kernel_impl(
       // ic0 + offset * 2 * N + nb * BLOCK_N,
       zero_buffer(C0, BLOCK_M * BLOCK_N);
       for (int kci = 0; kci < KB; ++kci) {
-        // auto scales_a = As + kci / block_per_group;
-        tinygemm_kernel2(//<true, BLOCK_N, 2, 3>(
-          /* C */ C0,
-          /* A */ A + kci * BLOCK_K,
-          /* scales_a */ As_ + kci / blocks_k_per_group,
-          /* B */ B + (nb * KB + kci) * BLOCK_K * BLOCK_N,
-          /* scales_b */ Bs + nb * BLOCK_N * num_groups + kci / blocks_k_per_group * BLOCK_N /*scales_b*/,
-          /* M */ m_size,
-          /* K */ BLOCK_K,
-          /* lda */ K,
-          /* ldc */ BLOCK_N,
-          /* ldsa */ ldsa,
-          /* ukernel_buf */ ukernel_buf,
-          /* dqA_buf */ nullptr,
-          /* dqB_buf */ nullptr);
+        // cpublas_can_pack = True, act_quant_mode = per row (2), wei_quant_mode = per group (3)
+        tinygemm_kernel(
+            /* C */ C0,
+            /* A */ A + kci * BLOCK_K,
+            /* scales_a */ As_ + kci / blocks_k_per_group,
+            /* B */ B + (nb * KB + kci) * BLOCK_K * BLOCK_N,
+            /* scales_b */ Bs + nb * BLOCK_N * num_groups + kci / blocks_k_per_group * BLOCK_N /*scales_b*/,
+            /* M */ m_size,
+            /* K */ BLOCK_K,
+            /* lda */ K,
+            /* ldc */ BLOCK_N,
+            /* ldsa */ ldsa,
+            /* ukernel_buf */ ukernel_buf_1,
+            /* dqA_buf */ nullptr,
+            /* dqB_buf */ nullptr);
       }
       store_out<scalar_t, BLOCK_N, 2, 3>(
-        C0, ic0 + offset * 2 * N + nb * BLOCK_N, m_size, 2*N /*lda*/, As_, nullptr, nullptr /*bias data*/);
+          C0, ic0 + offset * 2 * N + nb * BLOCK_N, m_size, 2 * N /*lda*/, As_, nullptr, nullptr /*bias data*/);
       zero_buffer(C1, BLOCK_M * BLOCK_N);
       for (int kci = 0; kci < KB; ++kci) {
-        // auto scales_a = As + kci / block_per_group;
-        tinygemm_kernel2(//<true, BLOCK_N, 2, 3>(
-          /* C */ C1,
-          /* A */ A + kci * BLOCK_K,
-          /* scales_a */ As_ + kci / blocks_k_per_group,
-          /* B */ B + (nb1 * KB + kci) * BLOCK_K * BLOCK_N,
-          /* scales_b */ Bs + nb1 * BLOCK_N * num_groups + kci / blocks_k_per_group * BLOCK_N /*scales_b*/,
-          /* M */ m_size,
-          /* K */ BLOCK_K,
-          /* lda */ K,
-          /* ldc */ BLOCK_N,
-          /* ldsa */ ldsa,
-          /* ukernel_buf */ ukernel_buf2,
-          /* dqA_buf */ nullptr,
-          /* dqB_buf */ nullptr);
+        // cpublas_can_pack = True, act_quant_mode = per row (2), wei_quant_mode = per group (3)
+        tinygemm_kernel(
+            /* C */ C1,
+            /* A */ A + kci * BLOCK_K,
+            /* scales_a */ As_ + kci / blocks_k_per_group,
+            /* B */ B + (nb1 * KB + kci) * BLOCK_K * BLOCK_N,
+            /* scales_b */ Bs + nb1 * BLOCK_N * num_groups + kci / blocks_k_per_group * BLOCK_N /*scales_b*/,
+            /* M */ m_size,
+            /* K */ BLOCK_K,
+            /* lda */ K,
+            /* ldc */ BLOCK_N,
+            /* ldsa */ ldsa,
+            /* ukernel_buf */ ukernel_buf_2,
+            /* dqA_buf */ nullptr,
+            /* dqB_buf */ nullptr);
       }
       store_out<scalar_t, BLOCK_N, 2, 3>(
-        C1, ic0 + offset * 2 * N + nb1 * BLOCK_N, m_size, 2*N /*lda*/, As_, nullptr, nullptr /*bias data*/);
+          C1, ic0 + offset * 2 * N + nb1 * BLOCK_N, m_size, 2 * N /*lda*/, As_, nullptr, nullptr /*bias data*/);
     }
     if (use_brgemm) {
       at::native::cpublas::brgemm_release();
@@ -376,6 +363,8 @@ void fused_experts_fp8_a8_kernel_impl(
   scale_size_K = div_up(N, block_size_K);
   const int64_t stride_e2 = OC * IC;
   const int64_t stride_oc = IC;
+  int64_t avg_M = std::max(int64_t(1), M * topk / E);
+  use_brgemm = can_use_brgemm<at::Float8_e4m3fn>(avg_M);
 
   // parallel on [MB2, NB2]
   parallel_2d(MB2, NB2, [&](int64_t mb0, int64_t mb1, int64_t nb0, int64_t nb1) {
@@ -441,36 +430,34 @@ void fused_experts_fp8_a8_kernel_impl(
   });
 }
 
-#define INSTANTIATE_MOE_FP8_A8_TEMPLATE(TYPE)             \
-  template void fused_experts_fp8_a8_kernel_impl<TYPE>(   \
-      TYPE* __restrict__ output,                       \
-      TYPE* __restrict__ ic0,                          \
-      TYPE* __restrict__ ic1,                          \
-      TYPE* __restrict__ ic2,                          \
-      at::Float8_e4m3fn* __restrict__ A_tmp,                        \
-      TYPE* __restrict__ B_tmp,                        \
-      float* __restrict__ C_tmp,                       \
-      const at::Float8_e4m3fn* __restrict__ input,                  \
-      const at::Float8_e4m3fn* __restrict__ packed_w1, \
-      const at::Float8_e4m3fn* __restrict__ packed_w2, \
-      const float* __restrict__ As,                   \
-      const float* __restrict__ w1s,                   \
-      const float* __restrict__ w2s,                   \
-      int64_t block_size_N,                            \
-      int64_t block_size_K,                            \
-      const float* __restrict__ topk_weights,          \
-      const int32_t* __restrict__ sorted_ids,          \
-      const int32_t* __restrict__ expert_ids,          \
-      const int32_t* __restrict__ offsets,             \
-      int64_t M,                                       \
-      int64_t N,                                       \
-      int64_t K,                                       \
-      int64_t E,                                       \
-      int64_t topk,                                    \
+#define INSTANTIATE_MOE_FP8_A8_TEMPLATE(TYPE)           \
+  template void fused_experts_fp8_a8_kernel_impl<TYPE>( \
+      TYPE* __restrict__ output,                        \
+      TYPE* __restrict__ ic0,                           \
+      TYPE* __restrict__ ic1,                           \
+      TYPE* __restrict__ ic2,                           \
+      at::Float8_e4m3fn* __restrict__ A_tmp,            \
+      TYPE* __restrict__ B_tmp,                         \
+      float* __restrict__ C_tmp,                        \
+      float* __restrict__ Ukernel_tmp,                  \
+      const at::Float8_e4m3fn* __restrict__ input,      \
+      const at::Float8_e4m3fn* __restrict__ packed_w1,  \
+      const at::Float8_e4m3fn* __restrict__ packed_w2,  \
+      const float* __restrict__ As,                     \
+      const float* __restrict__ w1s,                    \
+      const float* __restrict__ w2s,                    \
+      int64_t block_size_N,                             \
+      int64_t block_size_K,                             \
+      const float* __restrict__ topk_weights,           \
+      const int32_t* __restrict__ sorted_ids,           \
+      const int32_t* __restrict__ expert_ids,           \
+      const int32_t* __restrict__ offsets,              \
+      int64_t M,                                        \
+      int64_t N,                                        \
+      int64_t K,                                        \
+      int64_t E,                                        \
+      int64_t topk,                                     \
       int64_t num_tokens_post_pad)
-
-
 
 INSTANTIATE_MOE_FP8_A8_TEMPLATE(at::BFloat16);
 INSTANTIATE_MOE_FP8_A8_TEMPLATE(at::Half);
-

--- a/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
+++ b/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
@@ -221,7 +221,11 @@ void shm_allreduce(at::Tensor& data, int64_t op);
 
 // shared memory all_gather
 at::Tensor shm_allgather(at::Tensor& data, int64_t dim);
-
+std::tuple<at::Tensor, at::Tensor> _quantize_fp8e4m3(
+    const at::Tensor& t,
+    bool channelwise,
+    c10::optional<at::Tensor> scale_opt = c10::nullopt
+  );
 // rope
 std::tuple<at::Tensor, at::Tensor> rotary_embedding_cpu(
     at::Tensor& positions,
@@ -244,7 +248,17 @@ at::Tensor float8_linear_impl(
     const at::Tensor& weight_scales,
     const std::optional<at::Tensor>& bias,
     at::ScalarType output_dtype);
+at::Tensor fp8_scaled_mm_with_quant(
+    const at::Tensor& act,
+    const std::optional<at::Tensor>& act_scales,
+    bool channelwise,
+    const at::Tensor& weight,
+    const at::Tensor& weight_scales,
+    const std::optional<at::Tensor>& bias,
+    at::ScalarType output_dtype);
 TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
+ m.def("quantize_fp8e4m3(Tensor input, bool channelwise, Tensor? scale_opt) -> (Tensor,Tensor)");
+  m.impl("quantize_fp8e4m3", torch::kCPU, &_quantize_fp8e4m3);
   // activation
   m.def("silu_and_mul_cpu(Tensor input) -> Tensor");
   m.impl("silu_and_mul_cpu", torch::kCPU, &silu_and_mul_cpu);
@@ -255,9 +269,10 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
 
   m.def("float8_linear_prepack_cpu(Tensor weight, Tensor scales) -> (Tensor, Tensor)");
   m.impl("float8_linear_prepack_cpu", torch::kCPU, &float8_linear_prepack_impl);
-
   m.def("float8_linear_cpu(Tensor input, Tensor input_scales, Tensor weight, Tensor weight_scales, Tensor? bias, ScalarType output_dtype) -> Tensor");
   m.impl("float8_linear_cpu", torch::kCPU, &float8_linear_impl);
+  m.def("fp8_scaled_mm_with_quant(Tensor act, Tensor? act_scales, bool channelwise, Tensor weight, Tensor weight_scales, Tensor? bias, ScalarType output_dtype) -> Tensor");
+  m.impl("fp8_scaled_mm_with_quant", torch::kCPU, &fp8_scaled_mm_with_quant);
 
   // norm
   m.def("rmsnorm_cpu(Tensor input, Tensor weight, float eps) -> Tensor");

--- a/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
+++ b/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
@@ -221,11 +221,8 @@ void shm_allreduce(at::Tensor& data, int64_t op);
 
 // shared memory all_gather
 at::Tensor shm_allgather(at::Tensor& data, int64_t dim);
-std::tuple<at::Tensor, at::Tensor> _quantize_fp8e4m3(
-    const at::Tensor& t,
-    bool channelwise,
-    c10::optional<at::Tensor> scale_opt = c10::nullopt
-  );
+std::tuple<at::Tensor, at::Tensor>
+_quantize_fp8e4m3(const at::Tensor& t, bool channelwise, c10::optional<at::Tensor> scale_opt = c10::nullopt);
 // rope
 std::tuple<at::Tensor, at::Tensor> rotary_embedding_cpu(
     at::Tensor& positions,
@@ -237,10 +234,7 @@ std::tuple<at::Tensor, at::Tensor> rotary_embedding_cpu(
 
 // CPU and memory binding
 std::string init_cpu_threads_env(const std::string& cpu_ids);
-std::tuple<at::Tensor, at::Tensor>
-float8_linear_prepack_impl(
-    const at::Tensor& weight,
-    const at::Tensor& scales);
+std::tuple<at::Tensor, at::Tensor> float8_linear_prepack_impl(const at::Tensor& weight, const at::Tensor& scales);
 at::Tensor float8_linear_impl(
     const at::Tensor& input,
     const at::Tensor& input_scales,
@@ -256,9 +250,13 @@ at::Tensor fp8_scaled_mm_with_quant(
     const at::Tensor& weight_scales,
     const std::optional<at::Tensor>& bias,
     at::ScalarType output_dtype);
+std::tuple<at::Tensor, at::Tensor>
+_quantize_fp8e4m3_vec(const at::Tensor& t, bool channelwise, c10::optional<at::Tensor> scale_opt);
 TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
- m.def("quantize_fp8e4m3(Tensor input, bool channelwise, Tensor? scale_opt) -> (Tensor,Tensor)");
+  m.def("quantize_fp8e4m3(Tensor input, bool channelwise, Tensor? scale_opt) -> (Tensor,Tensor)");
   m.impl("quantize_fp8e4m3", torch::kCPU, &_quantize_fp8e4m3);
+  m.def("_quantize_fp8e4m3_vec(Tensor input, bool channelwise, Tensor? scale_opt) -> (Tensor,Tensor)");
+  m.impl("_quantize_fp8e4m3_vec", torch::kCPU, &_quantize_fp8e4m3_vec);
   // activation
   m.def("silu_and_mul_cpu(Tensor input) -> Tensor");
   m.impl("silu_and_mul_cpu", torch::kCPU, &silu_and_mul_cpu);
@@ -269,9 +267,13 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
 
   m.def("float8_linear_prepack_cpu(Tensor weight, Tensor scales) -> (Tensor, Tensor)");
   m.impl("float8_linear_prepack_cpu", torch::kCPU, &float8_linear_prepack_impl);
-  m.def("float8_linear_cpu(Tensor input, Tensor input_scales, Tensor weight, Tensor weight_scales, Tensor? bias, ScalarType output_dtype) -> Tensor");
+  m.def(
+      "float8_linear_cpu(Tensor input, Tensor input_scales, Tensor weight, Tensor weight_scales, Tensor? bias, "
+      "ScalarType output_dtype) -> Tensor");
   m.impl("float8_linear_cpu", torch::kCPU, &float8_linear_impl);
-  m.def("fp8_scaled_mm_with_quant(Tensor act, Tensor? act_scales, bool channelwise, Tensor weight, Tensor weight_scales, Tensor? bias, ScalarType output_dtype) -> Tensor");
+  m.def(
+      "fp8_scaled_mm_with_quant(Tensor act, Tensor? act_scales, bool channelwise, Tensor weight, Tensor weight_scales, "
+      "Tensor? bias, ScalarType output_dtype) -> Tensor");
   m.impl("fp8_scaled_mm_with_quant", torch::kCPU, &fp8_scaled_mm_with_quant);
 
   // norm
@@ -351,7 +353,8 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   // moe
   m.def(
       "fused_experts_cpu(Tensor hidden_states, Tensor w1, Tensor w2, Tensor topk_weights, Tensor topk_ids, bool "
-      "inplace, bool use_int8_w8a8, bool use_fp8_w8a16, bool use_fp8_w8a8,  Tensor? w1_scale, Tensor? w2_scale, int[]? block_size, Tensor? "
+      "inplace, bool use_int8_w8a8, bool use_fp8_w8a16, bool use_fp8_w8a8,  Tensor? w1_scale, Tensor? w2_scale, int[]? "
+      "block_size, Tensor? "
       "a1_scale, Tensor? a2_scale, bool "
       "is_vnni) -> Tensor");
   m.impl("fused_experts_cpu", torch::kCPU, &fused_experts_cpu);

--- a/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
+++ b/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
@@ -149,6 +149,7 @@ at::Tensor fused_experts_cpu(
     bool inplace,
     bool use_int8_w8a8,
     bool use_fp8_w8a16,
+    bool use_fp8_w8a8,
     const std::optional<at::Tensor>& w1_scale,
     const std::optional<at::Tensor>& w2_scale,
     const std::optional<std::vector<int64_t>> block_size,
@@ -335,7 +336,7 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   // moe
   m.def(
       "fused_experts_cpu(Tensor hidden_states, Tensor w1, Tensor w2, Tensor topk_weights, Tensor topk_ids, bool "
-      "inplace, bool use_int8_w8a8, bool use_fp8_w8a16, Tensor? w1_scale, Tensor? w2_scale, int[]? block_size, Tensor? "
+      "inplace, bool use_int8_w8a8, bool use_fp8_w8a16, bool use_fp8_w8a8,  Tensor? w1_scale, Tensor? w2_scale, int[]? block_size, Tensor? "
       "a1_scale, Tensor? a2_scale, bool "
       "is_vnni) -> Tensor");
   m.impl("fused_experts_cpu", torch::kCPU, &fused_experts_cpu);


### PR DESCRIPTION
# Accuracy
MMLU on DeepSeek r1:
```
subject: abstract_algebra, #q:100, acc: 0.770
subject: anatomy, #q:135, acc: 0.852
subject: astronomy, #q:152, acc: 0.941
subject: business_ethics, #q:100, acc: 0.870
subject: clinical_knowledge, #q:265, acc: 0.928
subject: college_biology, #q:144, acc: 0.972
subject: college_chemistry, #q:100, acc: 0.650
subject: college_computer_science, #q:100, acc: 0.840
subject: college_mathematics, #q:100, acc: 0.770
subject: college_medicine, #q:173, acc: 0.879
subject: college_physics, #q:102, acc: 0.824
subject: computer_security, #q:100, acc: 0.900
subject: conceptual_physics, #q:235, acc: 0.928
subject: econometrics, #q:114, acc: 0.737
subject: electrical_engineering, #q:145, acc: 0.869
subject: elementary_mathematics, #q:378, acc: 0.942
subject: formal_logic, #q:126, acc: 0.810
subject: global_facts, #q:100, acc: 0.690
subject: high_school_biology, #q:310, acc: 0.961
subject: high_school_chemistry, #q:203, acc: 0.862
subject: high_school_computer_science, #q:100, acc: 0.940
subject: high_school_european_history, #q:165, acc: 0.891
subject: high_school_geography, #q:198, acc: 0.960
subject: high_school_government_and_politics, #q:193, acc: 0.984
subject: high_school_macroeconomics, #q:390, acc: 0.921
subject: high_school_mathematics, #q:270, acc: 0.752
subject: high_school_microeconomics, #q:238, acc: 0.966
subject: high_school_physics, #q:151, acc: 0.848
subject: high_school_psychology, #q:545, acc: 0.972
subject: high_school_statistics, #q:216, acc: 0.856
subject: high_school_us_history, #q:204, acc: 0.951
subject: high_school_world_history, #q:237, acc: 0.941
subject: human_aging, #q:223, acc: 0.848
subject: human_sexuality, #q:131, acc: 0.939
subject: international_law, #q:121, acc: 0.950
subject: jurisprudence, #q:108, acc: 0.926
subject: logical_fallacies, #q:163, acc: 0.926
subject: machine_learning, #q:112, acc: 0.786
subject: management, #q:103, acc: 0.922
subject: marketing, #q:234, acc: 0.949
subject: medical_genetics, #q:100, acc: 0.950
subject: miscellaneous, #q:783, acc: 0.954
subject: moral_disputes, #q:346, acc: 0.873
subject: moral_scenarios, #q:895, acc: 0.765
subject: nutrition, #q:306, acc: 0.912
subject: philosophy, #q:311, acc: 0.894
subject: prehistory, #q:324, acc: 0.938
subject: professional_accounting, #q:282, acc: 0.872
subject: professional_law, #q:1534, acc: 0.707
subject: professional_medicine, #q:272, acc: 0.952
subject: professional_psychology, #q:612, acc: 0.910
subject: public_relations, #q:110, acc: 0.800
subject: security_studies, #q:245, acc: 0.886
subject: sociology, #q:201, acc: 0.970
subject: us_foreign_policy, #q:100, acc: 0.920
subject: virology, #q:166, acc: 0.590
subject: world_religions, #q:171, acc: 0.936
Total latency: 4983.492
Average accuracy: 0.871
```
LLama 8b fp8 MMLU:
```
subject: abstract_algebra, #q:100, acc: 0.330
subject: anatomy, #q:135, acc: 0.659
subject: astronomy, #q:152, acc: 0.763
subject: business_ethics, #q:100, acc: 0.750
subject: clinical_knowledge, #q:265, acc: 0.751
subject: college_biology, #q:144, acc: 0.792
subject: college_chemistry, #q:100, acc: 0.460
subject: college_computer_science, #q:100, acc: 0.570
subject: college_mathematics, #q:100, acc: 0.390
subject: college_medicine, #q:173, acc: 0.682
subject: college_physics, #q:102, acc: 0.431
subject: computer_security, #q:100, acc: 0.800
subject: conceptual_physics, #q:235, acc: 0.638
subject: econometrics, #q:114, acc: 0.509
subject: electrical_engineering, #q:145, acc: 0.703
subject: elementary_mathematics, #q:378, acc: 0.479
subject: formal_logic, #q:126, acc: 0.516
subject: global_facts, #q:100, acc: 0.360
subject: high_school_biology, #q:310, acc: 0.823
subject: high_school_chemistry, #q:203, acc: 0.606
subject: high_school_computer_science, #q:100, acc: 0.760
subject: high_school_european_history, #q:165, acc: 0.752
subject: high_school_geography, #q:198, acc: 0.848
subject: high_school_government_and_politics, #q:193, acc: 0.917
subject: high_school_macroeconomics, #q:390, acc: 0.695
subject: high_school_mathematics, #q:270, acc: 0.441
subject: high_school_microeconomics, #q:238, acc: 0.786
subject: high_school_physics, #q:151, acc: 0.477
subject: high_school_psychology, #q:545, acc: 0.866
subject: high_school_statistics, #q:216, acc: 0.583
subject: high_school_us_history, #q:204, acc: 0.828
subject: high_school_world_history, #q:237, acc: 0.835
subject: human_aging, #q:223, acc: 0.700
subject: human_sexuality, #q:131, acc: 0.817
subject: international_law, #q:121, acc: 0.818
subject: jurisprudence, #q:108, acc: 0.778
subject: logical_fallacies, #q:163, acc: 0.785
subject: machine_learning, #q:112, acc: 0.571
subject: management, #q:103, acc: 0.816
subject: marketing, #q:234, acc: 0.876
subject: medical_genetics, #q:100, acc: 0.810
subject: miscellaneous, #q:783, acc: 0.831
subject: moral_disputes, #q:346, acc: 0.751
subject: moral_scenarios, #q:895, acc: 0.544
subject: nutrition, #q:306, acc: 0.778
subject: philosophy, #q:311, acc: 0.711
subject: prehistory, #q:324, acc: 0.753
subject: professional_accounting, #q:282, acc: 0.504
subject: professional_law, #q:1534, acc: 0.518
subject: professional_medicine, #q:272, acc: 0.757
subject: professional_psychology, #q:612, acc: 0.724
subject: public_relations, #q:110, acc: 0.682
subject: security_studies, #q:245, acc: 0.739
subject: sociology, #q:201, acc: 0.866
subject: us_foreign_policy, #q:100, acc: 0.870
subject: virology, #q:166, acc: 0.500
subject: world_religions, #q:171, acc: 0.830
Total latency: 3878.692
Average accuracy: 0.682
```
# Performance

LLama 8b fp8 perf - bs1_1k1k_tp1（opt for quant part):
Before:
```
-------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  
                                 Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg    # of Calls  
-------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  
        sgl_kernel::float8_linear_cpu        85.45%        2.247s        85.49%        2.248s      17.561ms           128  
     sgl-kernel::extend_attention_cpu         4.12%     108.431ms         4.13%     108.495ms       3.390ms            32  
                            aten::div         3.34%      87.717ms         3.34%      87.717ms     685.293us           128  
                          aten::copy_         2.99%      78.737ms         2.99%      78.737ms     301.674us           261  
                          aten::clamp         2.10%      55.307ms         2.10%      55.336ms     432.310us           128  
         sgl-kernel::silu_and_mul_cpu         0.83%      21.792ms         0.84%      21.983ms     686.958us            32  
    sgl-kernel::fused_add_rmsnorm_cpu         0.36%       9.471ms         0.37%       9.746ms     152.282us            64  
     sgl-kernel::weight_packed_linear         0.25%       6.703ms         0.25%       6.704ms       6.704ms             1  
               aten::_index_put_impl_         0.11%       2.929ms         0.12%       3.074ms      48.024us            64  
     sgl-kernel::rotary_embedding_cpu         0.09%       2.352ms         0.10%       2.700ms      84.386us            32  
                       aten::_to_copy         0.05%       1.295ms         3.07%      80.626ms     312.503us           258  
                        aten::maximum         0.05%       1.215ms         0.05%       1.215ms       9.491us           128  
                          aten::empty         0.05%       1.187ms         0.05%       1.187ms       1.803us           658  
                           aten::view         0.04%     974.003us         0.04%     974.003us       3.025us           322  
                  aten::empty_strided         0.03%     818.318us         0.03%     818.318us       2.299us           356  
                             aten::to         0.02%     507.661us         3.09%      81.134ms     150.806us           538  
               aten::split_with_sizes         0.02%     420.169us         0.02%     595.882us      18.621us            32  
    sgl_kernel::fused_add_rmsnorm_cpu         0.01%     295.994us         0.38%      10.042ms     156.907us            64  
                         aten::argmax         0.01%     273.751us         0.01%     275.208us     275.208us             1  
                     aten::index_put_         0.01%     267.629us         0.13%       3.341ms      52.206us            64  
                            aten::max         0.01%     255.863us         0.06%       1.472ms      11.414us           129  
         sgl_kernel::silu_and_mul_cpu         0.01%     246.549us         0.85%      22.229ms     694.662us            32  
                     aten::empty_like         0.01%     237.576us         0.02%     445.350us       4.544us            98  
     sgl_kernel::extend_attention_cpu         0.01%     236.800us         4.14%     108.732ms       3.398ms            32  
                     aten::as_strided         0.01%     226.009us         0.01%     226.009us       1.263us           179  
     sgl_kernel::rotary_embedding_cpu         0.01%     223.327us         0.11%       2.924ms      91.365us            32  
                     aten::lift_fresh         0.00%      81.272us         0.00%      81.272us       0.576us           141  
                        aten::reshape         0.00%      78.032us         0.00%     108.054us       1.662us            65  
                   aten::index_select         0.00%      67.608us         0.00%      70.267us      70.267us             1  
              sgl-kernel::rmsnorm_cpu         0.00%      54.420us         0.00%      58.665us      58.665us             1  
                          aten::index         0.00%      45.224us         0.00%      51.329us      51.329us             1  
                         aten::cumsum         0.00%      35.337us         0.00%      66.737us      33.369us             2  
                            aten::sub         0.00%      29.834us         0.00%      29.834us      14.917us             2  
                          aten::fill_         0.00%      21.063us         0.00%      21.063us       7.021us             3  
                            aten::cat         0.00%      18.307us         0.00%      18.307us      18.307us             1  
                          aten::slice         0.00%      17.568us         0.00%      21.060us       3.009us             7  
                         aten::select         0.00%      17.313us         0.00%      20.103us       2.010us            10  
                          aten::alias         0.00%      14.634us         0.00%      14.634us      14.634us             1  
                            aten::add         0.00%      13.670us         0.00%      13.670us      13.670us             1  
                         aten::arange         0.00%      13.115us         0.00%      26.459us      13.229us             2  
                         aten::unbind         0.00%       7.706us         0.00%      10.137us       5.068us             2  
     sgl_kernel::weight_packed_linear         0.00%       7.692us         0.26%       6.711ms       6.711ms             1  
                           aten::item         0.00%       6.665us         0.00%      11.474us       1.639us             7  
                        aten::detach_         0.00%       5.173us         0.00%       9.668us       0.744us            13  
                      aten::embedding         0.00%       4.983us         0.00%      75.250us      75.250us             1  
            aten::_local_scalar_dense         0.00%       4.809us         0.00%       4.809us       0.687us             7  
                              detach_         0.00%       4.495us         0.00%       4.495us       0.346us            13  
                          aten::zero_         0.00%       4.133us         0.00%      24.047us       8.016us             3  
              sgl_kernel::rmsnorm_cpu         0.00%       3.981us         0.00%      62.646us      62.646us             1  
                     aten::zeros_like         0.00%       3.719us         0.00%       9.678us       9.678us             1  
                          aten::zeros         0.00%       2.489us         0.00%      20.791us      20.791us             1  
                        aten::resize_         0.00%       1.527us         0.00%       1.527us       1.527us             1  
-------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  
Self CPU time total: 2.629s

-------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  
                                                   Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg    # of Calls  
-------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  
                          sgl_kernel::float8_linear_cpu        80.55%      59.267ms        80.98%      59.582ms     465.487us           128  
                       sgl-kernel::weight_packed_linear         7.91%       5.820ms         7.91%       5.821ms       5.821ms             1  
                       sgl-kernel::decode_attention_cpu         3.28%       2.411ms         3.30%       2.427ms      75.832us            32  
                                            aten::copy_         1.51%       1.110ms         1.51%       1.110ms       4.269us           260  
                                              aten::div         0.63%     463.308us         0.63%     463.308us       3.620us           128  
                                         aten::_to_copy         0.56%     409.741us         2.27%       1.673ms       6.460us           259  
                           sgl-kernel::silu_and_mul_cpu         0.54%     397.833us         0.60%     439.644us      13.739us            32  
                                            aten::empty         0.51%     374.355us         0.51%     374.355us       0.582us           643  
                                             aten::view         0.46%     340.495us         0.46%     340.495us       1.170us           291  
                                            aten::clamp         0.46%     336.355us         0.47%     347.202us       2.713us           128  
                                          aten::maximum         0.43%     314.496us         0.43%     314.496us       2.457us           128  
                      sgl-kernel::fused_add_rmsnorm_cpu         0.42%     306.970us         0.57%     419.124us       6.549us            64  
                       sgl-kernel::rotary_embedding_cpu         0.34%     250.336us         0.46%     336.645us      10.520us            32  
                                           aten::argmax         0.30%     222.693us         0.30%     223.817us     223.817us             1  
                                    aten::empty_strided         0.30%     218.449us         0.30%     218.449us       0.612us           357  
                                               aten::to         0.22%     164.564us         2.50%       1.838ms       3.554us           517  
                                 aten::split_with_sizes         0.22%     158.905us         0.27%     202.153us       6.317us            32  
                             Torch-Compiled Region: 0/0         0.18%     135.152us         0.43%     319.405us     319.405us             1  
                      sgl_kernel::fused_add_rmsnorm_cpu         0.15%     113.210us         0.72%     532.334us       8.318us            64  
## Call CompiledFxGraph f4zxngn77yh4lxbbe26aewasiawg...         0.15%     109.290us         0.15%     109.290us     109.290us             1  
                                              aten::max         0.11%      83.229us         0.54%     397.725us       3.107us           128  
                       sgl_kernel::decode_attention_cpu         0.10%      74.123us         3.40%       2.501ms      78.149us            32  
                                       aten::empty_like         0.09%      69.294us         0.17%     124.604us       1.285us            97  
                 AOTDispatcher Runtime Wrapper Prologue         0.09%      65.422us         0.09%      65.422us      65.422us             1  
                       sgl_kernel::rotary_embedding_cpu         0.07%      54.451us         0.53%     391.096us      12.222us            32  
                           sgl_kernel::silu_and_mul_cpu         0.07%      50.270us         0.67%     489.914us      15.310us            32  
                                       aten::as_strided         0.06%      47.611us         0.06%      47.611us       0.467us           102  
                               TorchDynamo Cache Lookup         0.04%      29.268us         0.04%      29.268us      29.268us             1  
                                          aten::reshape         0.03%      24.159us         0.08%      55.586us       1.635us            34  
                                       aten::lift_fresh         0.03%      20.978us         0.03%      20.978us       0.164us           128  
                                            aten::fill_         0.02%      17.386us         0.02%      17.386us      17.386us             1  
                                 aten::_index_put_impl_         0.02%      13.536us         0.02%      15.758us      15.758us             1  
                                             aten::add_         0.02%      13.445us         0.02%      16.273us       5.424us             3  
                                            aten::slice         0.02%      13.033us         0.02%      14.964us       7.482us             2  
                                     aten::index_select         0.02%      12.082us         0.03%      18.487us      18.487us             1  
                                      Pregraph bytecode         0.01%       9.541us         0.01%       9.541us       9.541us             1  
                                sgl-kernel::rmsnorm_cpu         0.01%       7.242us         0.01%       9.960us       9.960us             1  
                                            aten::clone         0.01%       7.092us         0.02%      16.804us      16.804us             1  
                                       aten::index_put_         0.01%       6.906us         0.03%      22.664us      22.664us             1  
                                            aten::zeros         0.01%       6.495us         0.04%      29.029us      29.029us             1  
                                            aten::alias         0.01%       6.363us         0.01%       6.363us       6.363us             1  
                                        aten::embedding         0.01%       5.571us         0.03%      24.058us      24.058us             1  
                                           aten::select         0.01%       4.729us         0.01%       5.694us       2.847us             2  
                       sgl_kernel::weight_packed_linear         0.01%       4.226us         7.92%       5.825ms       5.825ms             1  
                                sgl_kernel::rmsnorm_cpu         0.00%       3.293us         0.02%      13.253us      13.253us             1  
                                            aten::zero_         0.00%       3.025us         0.03%      20.411us      20.411us             1  
-------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  
Self CPU time total: 73.577ms

```
After:
```
----------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  
                                    Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg    # of Calls  
----------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  
    sgl_kernel::fp8_scaled_mm_with_quant        92.35%        2.134s        93.60%        2.163s      16.901ms           128  
        sgl-kernel::extend_attention_cpu         4.25%      98.169ms         4.25%      98.237ms       3.070ms            32  
                             aten::copy_         1.08%      25.038ms         1.08%      25.038ms     188.254us           133  
            sgl-kernel::silu_and_mul_cpu         1.07%      24.690ms         1.08%      24.866ms     777.076us            32  
       sgl-kernel::fused_add_rmsnorm_cpu         0.43%       9.936ms         0.44%      10.182ms     159.087us            64  
        sgl-kernel::weight_packed_linear         0.29%       6.714ms         0.29%       6.715ms       6.715ms             1  
                  aten::_index_put_impl_         0.11%       2.570ms         0.12%       2.705ms      42.262us            64  
        sgl-kernel::rotary_embedding_cpu         0.10%       2.244ms         0.11%       2.505ms      78.272us            32  
                             aten::empty         0.05%       1.068ms         0.05%       1.068ms       1.623us           658  
                              aten::view         0.04%     950.286us         0.04%     950.286us       2.951us           322  
                     aten::empty_strided         0.03%     704.337us         0.03%     704.337us       1.978us           356  
                          aten::_to_copy         0.03%     668.244us         1.12%      25.852ms     198.862us           130  
                                aten::to         0.03%     578.797us         1.14%      26.431ms      93.727us           282  
                        aten::empty_like         0.02%     536.728us         0.05%       1.080ms       4.781us           226  
                              aten::item         0.02%     452.454us         0.03%     591.484us       4.381us           135  
                  aten::split_with_sizes         0.02%     393.962us         0.02%     542.156us      16.942us            32  
                        aten::index_put_         0.02%     364.082us         0.13%       3.069ms      47.951us            64  
                            aten::argmax         0.01%     280.341us         0.01%     282.364us     282.364us             1  
       sgl_kernel::fused_add_rmsnorm_cpu         0.01%     231.700us         0.45%      10.413ms     162.707us            64  
        sgl_kernel::extend_attention_cpu         0.01%     216.105us         4.26%      98.454ms       3.077ms            32  
                        aten::as_strided         0.01%     195.892us         0.01%     195.892us       1.094us           179  
            sgl_kernel::silu_and_mul_cpu         0.01%     155.903us         1.08%      25.022ms     781.948us            32  
        sgl_kernel::rotary_embedding_cpu         0.01%     140.642us         0.11%       2.645ms      82.667us            32  
               aten::_local_scalar_dense         0.01%     139.030us         0.01%     139.030us       1.030us           135  
                           aten::reshape         0.00%      67.239us         0.00%     103.397us       1.591us            65  
                      aten::index_select         0.00%      61.682us         0.00%      64.053us      64.053us             1  
                 sgl-kernel::rmsnorm_cpu         0.00%      53.736us         0.00%      58.187us      58.187us             1  
                             aten::index         0.00%      38.628us         0.00%      47.073us      47.073us             1  
                            aten::cumsum         0.00%      30.247us         0.00%      58.826us      29.413us             2  
                               aten::sub         0.00%      29.181us         0.00%      29.181us      14.590us             2  
                             aten::fill_         0.00%      20.080us         0.00%      20.080us       6.693us             3  
                             aten::slice         0.00%      18.862us         0.00%      22.262us       3.180us             7  
                            aten::select         0.00%      14.996us         0.00%      17.456us       1.746us            10  
                               aten::add         0.00%      13.387us         0.00%      13.387us      13.387us             1  
                             aten::alias         0.00%      12.839us         0.00%      12.839us      12.839us             1  
                               aten::cat         0.00%      11.701us         0.00%      11.701us      11.701us             1  
                            aten::arange         0.00%      10.269us         0.00%      21.618us      10.809us             2  
        sgl_kernel::weight_packed_linear         0.00%       8.191us         0.29%       6.723ms       6.723ms             1  
                               aten::max         0.00%       6.126us         0.00%       7.768us       7.768us             1  
                            aten::unbind         0.00%       5.901us         0.00%       7.685us       3.842us             2  
                         aten::embedding         0.00%       5.173us         0.00%      69.226us      69.226us             1  
                        aten::zeros_like         0.00%       4.864us         0.00%       9.395us       9.395us             1  
                           aten::detach_         0.00%       4.735us         0.00%       9.237us       0.711us            13  
                                 detach_         0.00%       4.502us         0.00%       4.502us       0.346us            13  
                 sgl_kernel::rmsnorm_cpu         0.00%       4.294us         0.00%      62.481us      62.481us             1  
                             aten::zero_         0.00%       3.164us         0.00%      22.119us       7.373us             3  
                             aten::zeros         0.00%       2.991us         0.00%      21.440us      21.440us             1  
                        aten::lift_fresh         0.00%       1.870us         0.00%       1.870us       0.144us            13  
                           aten::resize_         0.00%       1.786us         0.00%       1.786us       1.786us             1  
----------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  
Self CPU time total: 2.311s
-------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  
                                                   Name    Self CPU %      Self CPU   CPU total %     CPU total  CPU time avg    # of Calls  
-------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  
                   sgl_kernel::fp8_scaled_mm_with_quant        82.55%      57.607ms        85.23%      59.478ms     464.671us           128  
                       sgl-kernel::weight_packed_linear         8.04%       5.614ms         8.05%       5.614ms       5.614ms             1  
                       sgl-kernel::decode_attention_cpu         3.33%       2.320ms         3.35%       2.338ms      73.051us            32  
                                            aten::copy_         1.48%       1.032ms         1.48%       1.032ms       7.820us           132  
                           sgl-kernel::silu_and_mul_cpu         0.53%     372.256us         0.58%     404.288us      12.634us            32  
                                            aten::empty         0.44%     306.288us         0.44%     306.288us       0.476us           643  
                                             aten::view         0.40%     276.901us         0.40%     276.901us       0.952us           291  
                      sgl-kernel::fused_add_rmsnorm_cpu         0.36%     248.838us         0.46%     321.845us       5.029us            64  
                                           aten::argmax         0.33%     227.400us         0.33%     228.134us     228.134us             1  
                       sgl-kernel::rotary_embedding_cpu         0.30%     210.577us         0.39%     272.651us       8.520us            32  
                                         aten::_to_copy         0.24%     167.975us         1.78%       1.243ms       9.487us           131  
                                    aten::empty_strided         0.23%     162.233us         0.23%     162.233us       0.454us           357  
                             Torch-Compiled Region: 0/0         0.19%     135.965us         0.40%     278.544us     278.544us             1  
                                       aten::empty_like         0.19%     131.307us         0.35%     242.660us       1.078us           225  
                                 aten::split_with_sizes         0.17%     121.175us         0.23%     157.505us       4.922us            32  
## Call CompiledFxGraph f4zxngn77yh4lxbbe26aewasiawg...         0.15%     105.862us         0.15%     105.862us     105.862us             1  
                      sgl_kernel::fused_add_rmsnorm_cpu         0.13%      93.335us         0.59%     415.180us       6.487us            64  
                                             aten::item         0.13%      91.293us         0.17%     116.302us       0.909us           128  
                                               aten::to         0.13%      90.734us         1.91%       1.334ms       5.109us           261  
                       sgl_kernel::decode_attention_cpu         0.12%      86.700us         3.47%       2.424ms      75.760us            32  
                       sgl_kernel::rotary_embedding_cpu         0.09%      64.259us         0.48%     336.910us      10.528us            32  
                           sgl_kernel::silu_and_mul_cpu         0.06%      43.131us         0.64%     447.419us      13.982us            32  
                                       aten::as_strided         0.06%      39.813us         0.06%      39.813us       0.390us           102  
                               TorchDynamo Cache Lookup         0.04%      31.332us         0.04%      31.332us      31.332us             1  
                 AOTDispatcher Runtime Wrapper Prologue         0.04%      28.048us         0.04%      28.048us      28.048us             1  
                              aten::_local_scalar_dense         0.04%      25.009us         0.04%      25.009us       0.195us           128  
                                          aten::reshape         0.03%      20.309us         0.06%      43.525us       1.280us            34  
                                            aten::fill_         0.02%      16.623us         0.02%      16.623us      16.623us             1  
                                            aten::slice         0.02%      14.824us         0.02%      16.538us       8.269us             2  
                                             aten::add_         0.02%      14.720us         0.02%      17.381us       5.794us             3  
                                 aten::_index_put_impl_         0.02%      13.274us         0.02%      14.852us      14.852us             1  
                                     aten::index_select         0.02%      10.974us         0.02%      16.385us      16.385us             1  
                                      Pregraph bytecode         0.01%       8.669us         0.01%       8.669us       8.669us             1  
                                       aten::index_put_         0.01%       7.105us         0.03%      21.957us      21.957us             1  
                                            aten::clone         0.01%       6.498us         0.02%      14.801us      14.801us             1  
                                            aten::alias         0.01%       6.370us         0.01%       6.370us       6.370us             1  
                                        aten::embedding         0.01%       6.100us         0.03%      22.485us      22.485us             1  
                                            aten::zeros         0.01%       5.960us         0.04%      27.757us      27.757us             1  
                       sgl_kernel::weight_packed_linear         0.01%       5.163us         8.05%       5.620ms       5.620ms             1  
                                sgl-kernel::rmsnorm_cpu         0.01%       5.110us         0.01%       7.556us       7.556us             1  
                                           aten::select         0.01%       3.984us         0.01%       4.753us       2.377us             2  
                                sgl_kernel::rmsnorm_cpu         0.01%       3.732us         0.02%      11.288us      11.288us             1  
                                            aten::zero_         0.00%       2.916us         0.03%      19.539us      19.539us             1  
-------------------------------------------------------  ------------  ------------  ------------  ------------  ------------  ------------  
Self CPU time total: 69.786ms

```
