### PR TITLE
Add topk_transform_512_cpu kernel

### DIFF
--- a/python/sglang/srt/layers/attention/compressed/indexer.py
+++ b/python/sglang/srt/layers/attention/compressed/indexer.py
@@ -17,7 +17,7 @@ from sglang.srt.layers.attention.indexer_topk_capturer import (
     get_global_indexer_capturer,
 )
 from sglang.srt.layers.attention.nsa.triton_kernel import act_quant
-from sglang.srt.utils import is_hip
+from sglang.srt.utils import cpu_has_amx_support, is_cpu, is_hip
 
 if TYPE_CHECKING:
     from sglang.srt.layers.attention.compressed.compressor import CompressorBackend
@@ -25,6 +25,9 @@ if TYPE_CHECKING:
     from sglang.srt.mem_cache.deepseekv4_memory_pool import DeepSeekV4TokenToKVPool
     from sglang.srt.model_executor.forward_batch_info import ForwardBatch
     from sglang.srt.models.deepseek_v4 import C4Indexer
+
+
+_is_cpu_amx_available = is_cpu() and cpu_has_amx_support()
 
 def act_quant_pytorch(
     x: torch.Tensor, block_size: int = 128, scale_fmt: Optional[str] = None
@@ -245,6 +248,24 @@ def topk_transform_512_pytorch_vectorized(
             valid_topk, raw_indices, torch.tensor(-1, device=device, dtype=torch.int32)
         )
         out_raw_indices.copy_(raw_indices)
+
+
+def topk_transform_512_cpu(
+    scores: torch.Tensor,
+    seq_lens: torch.Tensor,
+    page_tables: torch.Tensor,
+    out_page_indices: torch.Tensor,
+    page_size: int,
+    out_raw_indices: Optional[torch.Tensor] = None,
+) -> None:
+    torch.ops.sgl_kernel.topk_transform_512_cpu(
+        scores,
+        seq_lens,
+        page_tables,
+        out_page_indices,
+        page_size,
+        out_raw_indices,
+    )
 
 
 @triton.jit
@@ -513,6 +534,15 @@ class C4IndexerBackend:
                 core_metadata.c4_sparse_page_indices,
                 indexer_metadata.c4_page_size,
                 indexer_metadata.topk_metadata,
+            )
+        elif _is_cpu_amx_available:
+            topk_transform_512_cpu(
+                logits,
+                indexer_metadata.c4_seq_lens,
+                core_metadata.page_table,
+                core_metadata.c4_sparse_page_indices,
+                indexer_metadata.c4_page_size,
+                raw_indices,
             )
         else:
             topk_transform_512(

--- a/sgl-kernel/csrc/cpu/topk.cpp
+++ b/sgl-kernel/csrc/cpu/topk.cpp
@@ -1,7 +1,117 @@
 #include "common.h"
 #include "vec.h"
 
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
 namespace {
+
+constexpr int C4_TOPK = 512;
+
+template <typename T>
+inline int64_t load_index_value(const T* __restrict__ ptr, int64_t idx) {
+  return static_cast<int64_t>(ptr[idx]);
+}
+
+struct TopKTransformElem {
+  float score;
+  int32_t index;
+};
+
+struct TopKTransformMinHeapCmp {
+  bool operator()(const TopKTransformElem& lhs, const TopKTransformElem& rhs) const {
+    if (lhs.score == rhs.score) {
+      return lhs.index > rhs.index;
+    }
+    return lhs.score > rhs.score;
+  }
+};
+
+template <typename seq_t, typename page_t>
+void topk_transform_512_cpu_kernel_impl(
+    const float* __restrict__ scores,
+    const seq_t* __restrict__ seq_lens,
+    const page_t* __restrict__ page_tables,
+    int32_t* __restrict__ out_page_indices,
+    int32_t* __restrict__ out_raw_indices,
+    int64_t batch_size,
+    int64_t max_seq_len,
+    int64_t page_table_stride,
+    int64_t out_stride,
+    int64_t page_size) {
+  TORCH_CHECK(page_size > 0, "page_size must be positive");
+  TORCH_CHECK((page_size & (page_size - 1)) == 0, "page_size must be a power of 2");
+  const int page_bits = page_size > 1 ? static_cast<int>(std::log2(static_cast<double>(page_size))) : 0;
+  const int64_t page_mask = page_size - 1;
+
+  at::parallel_for(0, batch_size, 0, [&](int64_t begin, int64_t end) {
+    std::vector<TopKTransformElem> heap;
+    heap.reserve(C4_TOPK);
+
+    for (int64_t b = begin; b < end; ++b) {
+      const float* __restrict__ scores_row = scores + b * max_seq_len;
+      const page_t* __restrict__ page_table_row = page_tables + b * page_table_stride;
+      int32_t* __restrict__ out_page_row = out_page_indices + b * out_stride;
+      int32_t* __restrict__ out_raw_row = out_raw_indices == nullptr ? nullptr : out_raw_indices + b * out_stride;
+
+      int64_t seq_len = load_index_value(seq_lens, b);
+      seq_len = std::max<int64_t>(0, std::min<int64_t>(seq_len, max_seq_len));
+      const int64_t valid_topk = std::min<int64_t>(seq_len, C4_TOPK);
+
+      auto store_slot = [&](int64_t slot, int32_t raw_index) {
+        if (raw_index < 0) {
+          out_page_row[slot] = -1;
+          if (out_raw_row != nullptr) {
+            out_raw_row[slot] = -1;
+          }
+          return;
+        }
+
+        const int64_t page_idx = static_cast<int64_t>(raw_index) >> page_bits;
+        const int64_t offset_in_page = static_cast<int64_t>(raw_index) & page_mask;
+        const int64_t physical_page = load_index_value(page_table_row, page_idx);
+        out_page_row[slot] = static_cast<int32_t>((physical_page << page_bits) | offset_in_page);
+        if (out_raw_row != nullptr) {
+          out_raw_row[slot] = raw_index;
+        }
+      };
+
+      if (seq_len <= C4_TOPK) {
+        for (int64_t i = 0; i < valid_topk; ++i) {
+          store_slot(i, static_cast<int32_t>(i));
+        }
+        for (int64_t i = valid_topk; i < C4_TOPK; ++i) {
+          store_slot(i, -1);
+        }
+        continue;
+      }
+
+      heap.clear();
+      for (int64_t i = 0; i < C4_TOPK; ++i) {
+        heap.push_back({scores_row[i], static_cast<int32_t>(i)});
+      }
+      std::make_heap(heap.begin(), heap.end(), TopKTransformMinHeapCmp());
+
+      for (int64_t i = C4_TOPK; i < seq_len; ++i) {
+        const float score = scores_row[i];
+        const TopKTransformElem& current_min = heap.front();
+        if (score > current_min.score || (score == current_min.score && static_cast<int32_t>(i) < current_min.index)) {
+          std::pop_heap(heap.begin(), heap.end(), TopKTransformMinHeapCmp());
+          heap.back() = {score, static_cast<int32_t>(i)};
+          std::push_heap(heap.begin(), heap.end(), TopKTransformMinHeapCmp());
+        }
+      }
+
+      for (int64_t i = 0; i < C4_TOPK; ++i) {
+        store_slot(i, heap[i].index);
+      }
+    }
+  });
+}
 
 template <typename scalar_t, int SIZE, std::enable_if_t<!std::is_same_v<scalar_t, float>, int> = 0>
 inline void softmax(float* __restrict__ out, const scalar_t* __restrict__ input) {
@@ -947,6 +1057,84 @@ std::tuple<at::Tensor, at::Tensor> hash_topk_cpu(
   }
 
   return std::make_tuple(topk_weights, topk_ids);
+}
+
+void topk_transform_512_cpu(
+    at::Tensor& scores,
+    at::Tensor& seq_lens,
+    at::Tensor& page_tables,
+    at::Tensor& out_page_indices,
+    int64_t page_size,
+    const std::optional<at::Tensor>& out_raw_indices) {
+  RECORD_FUNCTION(
+      "sgl-kernel::topk_transform_512_cpu",
+      std::vector<c10::IValue>({scores, seq_lens, page_tables, out_page_indices}));
+  CHECK_INPUT(scores);
+  CHECK_INPUT(seq_lens);
+  CHECK_INPUT(page_tables);
+  CHECK_INPUT(out_page_indices);
+
+  TORCH_CHECK(scores.scalar_type() == at::kFloat, "scores must be float32");
+  TORCH_CHECK(out_page_indices.scalar_type() == at::kInt, "out_page_indices must be int32");
+  TORCH_CHECK(scores.dim() == 2, "scores must be a 2D tensor");
+  TORCH_CHECK(seq_lens.dim() == 1, "seq_lens must be a 1D tensor");
+  TORCH_CHECK(page_tables.dim() == 2, "page_tables must be a 2D tensor");
+  TORCH_CHECK(out_page_indices.dim() == 2, "out_page_indices must be a 2D tensor");
+
+  const int64_t batch_size = scores.size(0);
+  const int64_t max_seq_len = scores.size(1);
+  TORCH_CHECK(seq_lens.size(0) == batch_size, "seq_lens row count must match scores");
+  TORCH_CHECK(page_tables.size(0) == batch_size, "page_tables row count must match scores");
+  TORCH_CHECK(out_page_indices.size(0) == batch_size, "out_page_indices row count must match scores");
+  TORCH_CHECK(out_page_indices.size(1) >= C4_TOPK, "out_page_indices must have at least 512 columns");
+
+  int32_t* raw_ptr = nullptr;
+  if (out_raw_indices.has_value()) {
+    at::Tensor raw = out_raw_indices.value();
+    CHECK_INPUT(raw);
+    TORCH_CHECK(raw.scalar_type() == at::kInt, "out_raw_indices must be int32");
+    TORCH_CHECK(raw.dim() == 2, "out_raw_indices must be a 2D tensor");
+    TORCH_CHECK(raw.sizes() == out_page_indices.sizes(), "out_raw_indices shape must match out_page_indices");
+    raw_ptr = raw.data_ptr<int32_t>();
+  }
+
+  auto launch_with_page_type = [&]<typename seq_t>() {
+    if (page_tables.scalar_type() == at::kInt) {
+      topk_transform_512_cpu_kernel_impl<seq_t, int32_t>(
+          scores.data_ptr<float>(),
+          seq_lens.data_ptr<seq_t>(),
+          page_tables.data_ptr<int32_t>(),
+          out_page_indices.data_ptr<int32_t>(),
+          raw_ptr,
+          batch_size,
+          max_seq_len,
+          page_tables.stride(0),
+          out_page_indices.stride(0),
+          page_size);
+    } else if (page_tables.scalar_type() == at::kLong) {
+      topk_transform_512_cpu_kernel_impl<seq_t, int64_t>(
+          scores.data_ptr<float>(),
+          seq_lens.data_ptr<seq_t>(),
+          page_tables.data_ptr<int64_t>(),
+          out_page_indices.data_ptr<int32_t>(),
+          raw_ptr,
+          batch_size,
+          max_seq_len,
+          page_tables.stride(0),
+          out_page_indices.stride(0),
+          page_size);
+    } else {
+      TORCH_CHECK(false, "page_tables must be int32 or int64");
+    }
+  };
+
+  if (seq_lens.scalar_type() == at::kInt) {
+    launch_with_page_type.template operator()<int32_t>();
+  } else if (seq_lens.scalar_type() == at::kLong) {
+    launch_with_page_type.template operator()<int64_t>();
+  } else {
+    TORCH_CHECK(false, "seq_lens must be int32 or int64");
+  }
 }
 
 std::tuple<at::Tensor, at::Tensor>

--- a/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
+++ b/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
@@ -97,6 +97,14 @@ std::tuple<at::Tensor, at::Tensor> hash_topk_cpu(
     int64_t num_experts,
     double routed_scaling_factor);
 
+void topk_transform_512_cpu(
+    at::Tensor& scores,
+    at::Tensor& seq_lens,
+    at::Tensor& page_tables,
+    at::Tensor& out_page_indices,
+    int64_t page_size,
+    const std::optional<at::Tensor>& out_raw_indices);
+
 // attention
 void decode_attention_cpu(
     at::Tensor& query,
@@ -439,6 +447,12 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "hash_topk_cpu(Tensor gating_output, Tensor tid2eid, int topk, str scoring_func, "
       "int num_fused_shared_experts, int num_experts, float routed_scaling_factor) -> (Tensor, Tensor)");
   m.impl("hash_topk_cpu", torch::kCPU, &hash_topk_cpu);
+
+  // DeepSeek V4 compressed attention top-k transform
+  m.def(
+      "topk_transform_512_cpu(Tensor scores, Tensor seq_lens, Tensor page_tables, Tensor(a!) out_page_indices, "
+      "int page_size, Tensor(a!)? out_raw_indices) -> ()");
+  m.impl("topk_transform_512_cpu", torch::kCPU, &topk_transform_512_cpu);
 
   // decode
   m.def(

--- a/test/srt/cpu/test_topk_transform_512_cpu.py
+++ b/test/srt/cpu/test_topk_transform_512_cpu.py
@@ -1,0 +1,108 @@
+import unittest
+
+import torch
+
+import sgl_kernel  # noqa: F401
+from sglang.srt.layers.attention.compressed.indexer import (
+    topk_transform_512_pytorch_vectorized,
+)
+from sglang.test.test_utils import CustomTestCase
+
+
+TOPK = 512
+
+
+class TestTopKTransform512CPU(CustomTestCase):
+    def _make_inputs(
+        self, batch_size, max_seq_len, page_size, seq_lens, page_dtype=torch.int32
+    ):
+        torch.manual_seed(2026)
+        scores = torch.randn(batch_size, max_seq_len, dtype=torch.float32)
+        scores += torch.arange(max_seq_len, dtype=torch.float32).unsqueeze(0) * 1e-6
+        seq_lens = torch.tensor(seq_lens, dtype=torch.int32)
+        num_pages = (max_seq_len + page_size - 1) // page_size
+        page_tables = (
+            torch.arange(batch_size * num_pages, dtype=page_dtype).reshape(
+                batch_size, num_pages
+            )
+            + 17
+        ).contiguous()
+        return scores.contiguous(), seq_lens, page_tables
+
+    def _run_pytorch_reference(self, scores, seq_lens, page_tables, page_size):
+        ref_page_indices = torch.empty((scores.size(0), TOPK), dtype=torch.int32)
+        ref_raw_indices = torch.empty_like(ref_page_indices)
+        topk_transform_512_pytorch_vectorized(
+            scores,
+            seq_lens,
+            page_tables,
+            ref_page_indices,
+            page_size,
+            ref_raw_indices,
+        )
+        return ref_page_indices, ref_raw_indices
+
+    def _assert_rows_equivalent(self, actual, expected, seq_lens):
+        for row, seq_len in enumerate(seq_lens.tolist()):
+            if seq_len <= TOPK:
+                torch.testing.assert_close(actual[row], expected[row], atol=0, rtol=0)
+            else:
+                actual_valid = actual[row][actual[row] >= 0].sort().values
+                expected_valid = expected[row][expected[row] >= 0].sort().values
+                torch.testing.assert_close(actual_valid, expected_valid, atol=0, rtol=0)
+                self.assertTrue((actual[row][actual[row] < 0] == -1).all())
+
+    def test_matches_reference_with_raw_indices(self):
+        page_size = 64
+        scores, seq_lens, page_tables = self._make_inputs(
+            batch_size=4,
+            max_seq_len=1536,
+            page_size=page_size,
+            seq_lens=[0, 17, 512, 1299],
+        )
+        out_page_indices = torch.empty((scores.size(0), TOPK), dtype=torch.int32)
+        out_raw_indices = torch.empty_like(out_page_indices)
+
+        torch.ops.sgl_kernel.topk_transform_512_cpu(
+            scores,
+            seq_lens,
+            page_tables,
+            out_page_indices,
+            page_size,
+            out_raw_indices,
+        )
+        ref_page_indices, ref_raw_indices = self._run_pytorch_reference(
+            scores, seq_lens, page_tables, page_size
+        )
+
+        self._assert_rows_equivalent(out_raw_indices, ref_raw_indices, seq_lens)
+        self._assert_rows_equivalent(out_page_indices, ref_page_indices, seq_lens)
+
+    def test_matches_reference_without_raw_indices(self):
+        page_size = 32
+        scores, seq_lens, page_tables = self._make_inputs(
+            batch_size=3,
+            max_seq_len=777,
+            page_size=page_size,
+            seq_lens=[1, 600, 777],
+            page_dtype=torch.int64,
+        )
+        out_page_indices = torch.empty((scores.size(0), TOPK), dtype=torch.int32)
+
+        torch.ops.sgl_kernel.topk_transform_512_cpu(
+            scores,
+            seq_lens.to(torch.int64),
+            page_tables,
+            out_page_indices,
+            page_size,
+            None,
+        )
+        ref_page_indices, _ = self._run_pytorch_reference(
+            scores, seq_lens, page_tables, page_size
+        )
+
+        self._assert_rows_equivalent(out_page_indices, ref_page_indices, seq_lens)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION

## Modifications
Add `topk_transform_512_cpu` kernel to replace `topk_transform_512_pytorch_vectorized`.

## Benchmark
You need to remove `SGLANG_TOPK_TRANSFORM_512_TORCH=1` from the command line so that the `topk_transform_512_cpu` kernel can be used.

### Accuracy
gsm8k Accuracy: 0.965
Cmd:
```sh
# server
SGLANG_CPU_OMP_THREADS_BIND=0-39|40-79 \
SGLANG_OPT_BF16_FP32_GEMM_ALGO=torch \
SGLANG_OPT_USE_TILELANG_MHC_SPLIT_SINKHORN=false \
SGLANG_OPT_USE_TILELANG_SWA_PREPARE=false \
SGLANG_OPT_USE_JIT_KERNEL_FUSED_TOPK=false \
SGLANG_OPT_USE_FUSED_HASH_TOPK=false \
SGLANG_HACK_FLASHMLA_BACKEND=cpu_amx \
SGLANG_OPT_DEEPGEMM_HC_PRENORM=false \
SGLANG_OPT_USE_TILELANG_MHC_PRE=false \
SGLANG_OPT_USE_TILELANG_MHC_POST=false \
SGLANG_FP8_PAGED_MQA_LOGITS_TORCH=1 \
SGLANG_DSV4_FP4_EXPERTS=true \
SGLANG_OPT_USE_OVERLAP_STORE_CACHE=false \
SGLANG_OPT_USE_FUSED_STORE_CACHE=false \
SGLANG_OPT_USE_OLD_COMPRESSOR=true \
SGLANG_OPT_USE_FUSED_COMPRESS=false \
SGLANG_OPT_USE_FUSED_PAGED_COMPRESS=false \
SGLANG_OPT_DPSK_V4_RADIX=false \
python -m sglang.launch_server \
  --model \
  deepseek-ai/DeepSeek-V4-Flash \
  --trust-remote-code \
  --tp \
  2 \
  --attention-backend \
  compressed \
  --page-size \
  128 \
  --disable-shared-experts-fusion \
  --disable-cuda-graph \
  --tool-call-parser \
  deepseekv4 \
  --reasoning-parser \
  deepseek-v4

# client
python3 -m sglang.test.few_shot_gsm8k --num-questions 200
```

### Performance
bs=1, input=256, output=16
TP=2, 40 cores per rank

5% speedup for TPOT
No obvious change for TTFT

Cmd:
```sh
SGLANG_CPU_OMP_THREADS_BIND=0-39|40-79 \
SGLANG_OPT_BF16_FP32_GEMM_ALGO=torch \
SGLANG_OPT_USE_TILELANG_MHC_SPLIT_SINKHORN=false \
SGLANG_OPT_USE_TILELANG_SWA_PREPARE=false \
SGLANG_OPT_USE_JIT_KERNEL_FUSED_TOPK=false \
SGLANG_OPT_USE_FUSED_HASH_TOPK=false \
SGLANG_HACK_FLASHMLA_BACKEND=cpu_amx \
SGLANG_OPT_DEEPGEMM_HC_PRENORM=false \
SGLANG_OPT_USE_TILELANG_MHC_PRE=false \
SGLANG_OPT_USE_TILELANG_MHC_POST=false \
SGLANG_FP8_PAGED_MQA_LOGITS_TORCH=1 \
SGLANG_DSV4_FP4_EXPERTS=true \
SGLANG_OPT_USE_OVERLAP_STORE_CACHE=false \
SGLANG_OPT_USE_FUSED_STORE_CACHE=false \
SGLANG_OPT_USE_OLD_COMPRESSOR=true \
SGLANG_OPT_USE_FUSED_COMPRESS=false \
SGLANG_OPT_USE_FUSED_PAGED_COMPRESS=false \
SGLANG_OPT_DPSK_V4_RADIX=false \
python -m sglang.bench_one_batch \
  --model \
  deepseek-ai/DeepSeek-V4-Flash \
  --trust-remote-code \
  --tp \
  2 \
  --attention-backend \
  compressed \
  --page-size \
  128 \
  --disable-shared-experts-fusion \
  --disable-cuda-graph \
  --tool-call-parser \
  deepseekv4 \
  --reasoning-parser \
  deepseek-v4 \
  --disable-radix-cache \
  --batch-size \
  1 \
  --input-len \
  256 \
  --output-len \
  16
```