### PR TITLE
Fix accuracy issue caused by packed linear weight

### DIFF
--- a/python/sglang/jit_kernel/deepseek_v4.py
+++ b/python/sglang/jit_kernel/deepseek_v4.py
@@ -1196,7 +1196,7 @@ def _dispatch_bf16_fp32_backend(
         return z
     elif algo == "cpu_amx":
         return torch.ops.sgl_kernel.weight_packed_linear(
-            x, y, None, False, torch.float32
+            x, y, None, True, torch.float32
         )
     else:
         return torch.nn.functional.linear(x.float(), y.float())

--- a/python/sglang/jit_kernel/deepseek_v4.py
+++ b/python/sglang/jit_kernel/deepseek_v4.py
@@ -1194,6 +1194,10 @@ def _dispatch_bf16_fp32_backend(
         z = x.new_empty(x.size(0), y.size(0), dtype=torch.float32)
         deep_gemm.bf16_gemm_nt(x, y, z)
         return z
+    elif algo == "cpu_amx":
+        return torch.ops.sgl_kernel.weight_packed_linear(
+            x, y, None, False, torch.float32
+        )
     else:
         return torch.nn.functional.linear(x.float(), y.float())
 

--- a/python/sglang/srt/layers/amx_utils.py
+++ b/python/sglang/srt/layers/amx_utils.py
@@ -96,3 +96,42 @@ class PackWeightMethod:
         _amx_process_weight_after_loading(
             module, self.weight_names, self.transpose_dims
         )
+
+
+class PackWeightMethodBMM:
+    """Pack weight for batched matrix multiplication (bmm_cpu).
+
+    Replaces the default UnquantizedLinearMethod on a linear layer so that
+    the 2D weight [G*R, D] is reshaped to 3D [G, R, D] and then VNNI-packed.
+    """
+
+    def __init__(self, n_groups, group_size):
+        self.n_groups = n_groups
+        self.group_size = group_size
+
+    def process_weights_after_loading(self, module) -> None:
+        weight = module.weight
+        device = weight.device
+
+        # Reshape [G*R, D] → [G, R, D] for batched GEMM
+        weight_3d = weight.data.view(
+            self.n_groups, self.group_size, -1
+        ).contiguous()
+
+        if not dim_is_supported(weight_3d):
+            logger.warning(
+                f"Unsupported dimension for prepacking for weight "
+                f"'weight' with shape {weight_3d.shape} in {module}. "
+                f"The derived (OC, IC) dimensions must be divisible by (16, 32). "
+            )
+            module.use_intel_amx_backend = False
+            return
+
+        packed_weight = torch.nn.Parameter(
+            amx_process_weight_after_loading(weight_3d),
+            requires_grad=False,
+        )
+        module.weight = packed_weight
+        module.use_intel_amx_backend = (
+            device == torch.device("cpu") and cpu_has_amx_support()
+        )

--- a/python/sglang/srt/layers/quantization/unquant.py
+++ b/python/sglang/srt/layers/quantization/unquant.py
@@ -120,9 +120,8 @@ class UnquantizedLinearMethod(LinearMethodBase):
         set_weight_attrs(weight, extra_weight_attrs)
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
-        # if _is_cpu and _is_cpu_amx_available:
-        #     _amx_process_weight_after_loading(layer, ["weight"])
-        pass
+        if _is_cpu and _is_cpu_amx_available:
+            _amx_process_weight_after_loading(layer, ["weight"])
 
     def apply(
         self,

--- a/python/sglang/srt/model_executor/cpu_graph_runner.py
+++ b/python/sglang/srt/model_executor/cpu_graph_runner.py
@@ -226,8 +226,11 @@ def register_fake_ops():
         return q_input, k_input, v_input
 
     @torch.library.register_fake("sgl_kernel::weight_packed_linear")
-    def _(x, weight, bias, is_vnni):
-        return x.new_empty(x.shape[0], weight.shape[0])
+    def _(x, weight, bias, is_vnni, out_dtype=None):
+        M = x.shape[0]
+        N = weight.shape[0]
+        dtype = out_dtype if out_dtype is not None else x.dtype
+        return x.new_empty(M, N, dtype=dtype)
 
     @torch.library.register_fake("sgl_kernel::per_token_quant_int8_cpu")
     def _(input):

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -69,6 +69,7 @@ from sglang.srt.model_loader.utils import maybe_executor_submit, should_async_lo
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.dbrx import ReplicatedLinear
 from sglang.srt.models.deepseek_v2 import ParallelLMHead, _is_cuda, _is_hip, _is_npu
+from sglang.srt.models.deepseek_common.utils import _is_cpu, _is_cpu_amx_available
 from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import (
     BumpAllocator,
@@ -77,6 +78,7 @@ from sglang.srt.utils import (
     log_info_on_rank0,
     make_layers,
     maybe_torch_compile,
+    use_intel_amx_backend,
 )
 
 logger = logging.getLogger(__name__)
@@ -853,6 +855,13 @@ class MQALayer(nn.Module):
                 self.wo_a, "weight_scale_inv"
             ), "FP8 quant_config must create weight_scale_inv"
             self.wo_a.weight_scale_inv.format_ue8m0 = True
+        elif _is_cpu and _is_cpu_amx_available:
+            from sglang.srt.layers.amx_utils import PackWeightMethodBMM
+
+            self.wo_a.quant_method = PackWeightMethodBMM(
+                n_groups=self.n_local_groups,
+                group_size=self.o_lora_rank,
+            )
         self.wo_b = RowParallelLinear(
             self.n_groups * self.o_lora_rank,
             self.hidden_size,
@@ -1159,6 +1168,19 @@ class MQALayer(nn.Module):
                 recipe=(1, 1, 128),
             )
             o = output
+        elif use_intel_amx_backend(self.wo_a):
+            T, G, D = o.shape
+            R = self.o_lora_rank
+            output = torch.empty([T, G, R], dtype=o.dtype, device=o.device)
+            torch.ops.sgl_kernel.bmm_cpu(
+                output.transpose(0, 1),  # [G, T, R]
+                o.transpose(0, 1),  # [G, T, D]
+                self.wo_a.weight,  # [G, R, D] packed in VNNI
+                True,  # is_vnni
+                None,  # scale
+            )
+            o = output
+
         else:
             wo_a = self.wo_a.weight.view(self.n_local_groups, self.o_lora_rank, -1)
             o = torch.einsum("tgd,grd->tgr", o, wo_a)

--- a/sgl-kernel/csrc/cpu/gemm.cpp
+++ b/sgl-kernel/csrc/cpu/gemm.cpp
@@ -162,6 +162,21 @@ inline void copy_add_stub(
   }
 }
 
+inline void copy_add_stub(
+    float* __restrict__ out, const float* __restrict__ input, const float* __restrict__ bias, int64_t size) {
+  using fVec = at::vec::Vectorized<float>;
+
+  int64_t d;
+#pragma GCC unroll 4
+  for (d = 0; d <= size - fVec::size(); d += fVec::size()) {
+    fVec data = fVec::loadu(input + d) + fVec::loadu(bias + d);
+    data.store(out + d);
+  }
+  for (; d < size; ++d) {
+    out[d] = input[d] + bias[d];
+  }
+}
+
 template <typename scalar_t, bool has_bias>
 inline void scalar_sigmoid_and_mul(
     scalar_t* __restrict__ out,
@@ -582,6 +597,62 @@ void weight_packed_linear_kernel_impl(
   });
 }
 
+// bf16/fp16 input, bf16/fp16 weight (vnni packed) -> fp32 output
+template <typename scalar_t>
+void weight_packed_linear_fp32_out_kernel_impl(
+    float* __restrict__ out,
+    const scalar_t* __restrict__ mat1,
+    const scalar_t* __restrict__ mat2,
+    const float* __restrict__ bias,
+    int64_t M,
+    int64_t N,
+    int64_t K,
+    int64_t mat1_strideM,
+    int64_t out_strideM) {
+  constexpr int64_t BLOCK_M = block_size_m();
+  constexpr int64_t BLOCK_N = block_size_n();
+  const int64_t MB = div_up(M, BLOCK_M);
+  const int64_t NB = div_up(N, BLOCK_N);
+
+  AT_DISPATCH_BOOL(bias != nullptr, has_bias, [&] {
+    parallel_2d(MB, NB, [&](int64_t mb0, int64_t mb1, int64_t nb0, int64_t nb1) {
+      alignas(64) float Ctmp[BLOCK_M * BLOCK_N];
+
+      loop_2d<scalar_t>(mb0, mb1, nb0, nb1, BLOCK_N * K, [&](int64_t mb, int64_t nb, int64_t nb_offset) {
+        int64_t mb_start = mb * BLOCK_M;
+        int64_t mb_size = std::min(M - mb_start, BLOCK_M);
+        int64_t nb_start = nb * BLOCK_N;
+        int64_t nb_size = std::min(N - nb_start, BLOCK_N);
+
+        // bf16 * bf16 -> fp32 accumulation via brgemm
+        at::native::cpublas::brgemm(
+            mb_size, nb_size, K,
+            mat1_strideM, nb_size, BLOCK_N,
+            /* add_C */ false,
+            mat1 + mb_start * mat1_strideM,
+            mat2 + nb_start * K,
+            Ctmp);
+
+        // copy Ctmp (fp32) directly to fp32 output
+        for (int64_t m = 0; m < mb_size; ++m) {
+          if constexpr (has_bias) {
+            copy_add_stub(
+                out + mb_start * out_strideM + nb_start + m * out_strideM,
+                Ctmp + m * BLOCK_N, bias + nb_start, nb_size);
+          } else {
+            std::memcpy(
+                out + mb_start * out_strideM + nb_start + m * out_strideM,
+                Ctmp + m * BLOCK_N,
+                nb_size * sizeof(float));
+          }
+        }
+      });
+
+      at::native::cpublas::brgemm_release();
+    });
+  });
+}
+
 }  // anonymous namespace
 
 // tinygemm interface
@@ -730,7 +801,12 @@ at::Tensor convert_scale_packed(at::Tensor& scale) {
 // out  : [M, N]
 //
 at::Tensor
-weight_packed_linear(at::Tensor& mat1, at::Tensor& mat2, const std::optional<at::Tensor>& bias, bool is_vnni) {
+weight_packed_linear(
+    at::Tensor& mat1,
+    at::Tensor& mat2,
+    const std::optional<at::Tensor>& bias,
+    bool is_vnni,
+    std::optional<at::ScalarType> out_dtype) {
   RECORD_FUNCTION("sgl-kernel::weight_packed_linear", std::vector<c10::IValue>({mat1, mat2, bias}));
 
   auto packed_w = is_vnni ? mat2 : convert_weight_packed(mat2);
@@ -752,7 +828,10 @@ weight_packed_linear(at::Tensor& mat1, at::Tensor& mat2, const std::optional<at:
   }
 
   auto dispatch_type = mat1.scalar_type();
-  auto out = at::empty({M, N}, mat1.options());
+  auto out_scalar_type = out_dtype.value_or(dispatch_type);
+  bool fp32_out = (out_scalar_type == at::kFloat) && (dispatch_type != at::kFloat);
+
+  auto out = at::empty({M, N}, mat1.options().dtype(out_scalar_type));
   // strides
   int64_t out_strideM = out.stride(0);
   int64_t mat1_strideM = mat1.stride(0);
@@ -764,22 +843,10 @@ weight_packed_linear(at::Tensor& mat1, at::Tensor& mat2, const std::optional<at:
     bias_data = bias.value().data_ptr<float>();
   }
 
-  AT_DISPATCH_REDUCED_FLOATING_TYPES(dispatch_type, "weight_packed_linear_kernel_impl", [&] {
-    if (use_fma_gemm) {
-      weight_packed_linear_kernel_impl<scalar_t>(
-          out.data_ptr<scalar_t>(),
-          mat1.data_ptr<scalar_t>(),
-          packed_w.data_ptr<float>(),
-          bias_data,
-          nullptr,
-          M,
-          N,
-          K,
-          mat1_strideM,
-          out_strideM);
-    } else {
-      weight_packed_linear_kernel_impl<scalar_t>(
-          out.data_ptr<scalar_t>(),
+  if (fp32_out && !use_fma_gemm) {
+    AT_DISPATCH_REDUCED_FLOATING_TYPES(dispatch_type, "weight_packed_linear_fp32_out", [&] {
+      weight_packed_linear_fp32_out_kernel_impl<scalar_t>(
+          out.data_ptr<float>(),
           mat1.data_ptr<scalar_t>(),
           packed_w.data_ptr<scalar_t>(),
           bias_data,
@@ -788,8 +855,35 @@ weight_packed_linear(at::Tensor& mat1, at::Tensor& mat2, const std::optional<at:
           K,
           mat1_strideM,
           out_strideM);
-    }
-  });
+    });
+  } else {
+    AT_DISPATCH_REDUCED_FLOATING_TYPES(dispatch_type, "weight_packed_linear_kernel_impl", [&] {
+      if (use_fma_gemm) {
+        weight_packed_linear_kernel_impl<scalar_t>(
+            out.data_ptr<scalar_t>(),
+            mat1.data_ptr<scalar_t>(),
+            packed_w.data_ptr<float>(),
+            bias_data,
+            nullptr,
+            M,
+            N,
+            K,
+            mat1_strideM,
+            out_strideM);
+      } else {
+        weight_packed_linear_kernel_impl<scalar_t>(
+            out.data_ptr<scalar_t>(),
+            mat1.data_ptr<scalar_t>(),
+            packed_w.data_ptr<scalar_t>(),
+            bias_data,
+            M,
+            N,
+            K,
+            mat1_strideM,
+            out_strideM);
+      }
+    });
+  }
 
   return out;
 }

--- a/sgl-kernel/csrc/cpu/qkv_proj.cpp
+++ b/sgl-kernel/csrc/cpu/qkv_proj.cpp
@@ -387,7 +387,12 @@ void rotary_emb_kernel_impl(
 }  // anonymous namespace
 
 extern at::Tensor
-weight_packed_linear(at::Tensor& mat1, at::Tensor& mat2, const std::optional<at::Tensor>& bias, bool is_vnni);
+weight_packed_linear(
+    at::Tensor& mat1,
+    at::Tensor& mat2,
+    const std::optional<at::Tensor>& bias,
+    bool is_vnni,
+    std::optional<at::ScalarType> out_dtype = c10::nullopt);
 
 extern at::Tensor int8_scaled_mm_with_quant(
     at::Tensor& mat1,

--- a/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
+++ b/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
@@ -169,7 +169,12 @@ std::tuple<at::Tensor, at::Tensor> per_token_quant_int8_cpu(at::Tensor& A);
 
 // gemm
 at::Tensor
-weight_packed_linear(at::Tensor& mat1, at::Tensor& mat2, const std::optional<at::Tensor>& bias, bool is_vnni);
+weight_packed_linear(
+    at::Tensor& mat1,
+    at::Tensor& mat2,
+    const std::optional<at::Tensor>& bias,
+    bool is_vnni,
+    std::optional<at::ScalarType> out_dtype = c10::nullopt);
 
 // gemm fusion
 at::Tensor fused_linear_sigmoid_mul(
@@ -477,7 +482,7 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   m.impl("per_token_quant_int8_cpu", torch::kCPU, &per_token_quant_int8_cpu);
 
   // gemm
-  m.def("weight_packed_linear(Tensor mat1, Tensor mat2, Tensor? bias, bool is_vnni) -> Tensor");
+  m.def("weight_packed_linear(Tensor mat1, Tensor mat2, Tensor? bias, bool is_vnni, ScalarType? out_dtype=None) -> Tensor");
   m.impl("weight_packed_linear", torch::kCPU, &weight_packed_linear);
 
   // gemm fusion

--- a/test/srt/cpu/test_gemm.py
+++ b/test/srt/cpu/test_gemm.py
@@ -277,6 +277,41 @@ class TestGemm(CustomTestCase):
             ):
                 self._int4_awq_gemm(*params)
 
+    def _bf16_fp32_gemm(self, M, N, K, has_bias):
+        mat1 = torch.randn(M, K, dtype=torch.bfloat16)
+        mat2 = torch.randn(N, K, dtype=torch.bfloat16)
+        bias = torch.randn(N, dtype=torch.float32) if has_bias else None
+
+        ref = torch.nn.functional.linear(
+            mat1.float(), mat2.float(), bias
+        )
+
+        out = torch.ops.sgl_kernel.weight_packed_linear(
+            mat1, mat2, bias, False, torch.float32
+        )
+        self.assertEqual(out.dtype, torch.float32)
+        atol = rtol = precision[torch.float32]
+        torch.testing.assert_close(ref, out, atol=atol, rtol=rtol)
+
+        packed_mat2 = torch.ops.sgl_kernel.convert_weight_packed(mat2)
+        out2 = torch.ops.sgl_kernel.weight_packed_linear(
+            mat1, packed_mat2, bias, True, torch.float32
+        )
+        self.assertEqual(out2.dtype, torch.float32)
+        torch.testing.assert_close(ref, out2, atol=atol, rtol=rtol)
+
+    def test_bf16_fp32_gemm(self):
+        for params in itertools.product(
+            self.M, self.N, self.K, self.has_bias
+        ):
+            with self.subTest(
+                M=params[0],
+                N=params[1],
+                K=params[2],
+                has_bias=params[3],
+            ):
+                self._bf16_fp32_gemm(*params)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Acc test:

server: `SGLANG_OPT_BF16_FP32_GEMM_ALGO=cpu_amx SGLANG_OPT_USE_TILELANG_MHC_SPLIT_SINKHORN=false SGLANG_OPT_USE_TILELANG_SWA_PREPARE=false SGLANG_OPT_USE_JIT_KERNEL_FUSED_TOPK=false SGLANG_OPT_USE_FUSED_HASH_TOPK=false SGLANG_HACK_FLASHMLA_BACKEND=cpu_amx SGLANG_OPT_DEEPGEMM_HC_PRENORM=false SGLANG_OPT_USE_TILELANG_MHC_PRE=false SGLANG_OPT_USE_TILELANG_MHC_POST=false SGLANG_TOPK_TRANSFORM_512_TORCH=1 SGLANG_FP8_PAGED_MQA_LOGITS_TORCH=1 SGLANG_DSV4_FP4_EXPERTS=true SGLANG_OPT_USE_OVERLAP_STORE_CACHE=false SGLANG_OPT_USE_FUSED_STORE_CACHE=false SGLANG_OPT_USE_OLD_COMPRESSOR=true SGLANG_OPT_USE_FUSED_COMPRESS=false SGLANG_OPT_USE_FUSED_PAGED_COMPRESS=false SGLANG_OPT_DPSK_V4_RADIX=false SGLANG_CPU_OMP_THREADS_BIND="96-127|128-159" python -m sglang.launch_server --model-path /localdisk/models/hub/ds-v4-flash/ --trust-remote-code --tp 2 --attention-backend compressed --page-size 256 --disable-shared-experts-fusion --disable-cuda-graph --tool-call-parser deepseekv4 --reasoning-parser deepseek-v4`

client: `python -m sglang.test.few_shot_gsm8k --num-questions 200`

result:
<img width="2440" height="201" alt="image" src="https://github.com/user-attachments/assets/6799d94d-d5bd-46b5-95d3-7ec58343c98f" />

