### PR TITLE
Support TP=3 or TP=6 for DeepSeek V4

### DIFF
--- a/python/sglang/srt/configs/update_config.py
+++ b/python/sglang/srt/configs/update_config.py
@@ -54,6 +54,15 @@ def get_num_heads_padding_size(tp_size, weight_block_size, head_dim):
     return pad_size
 
 
+def _set_padded_attr(model_config, attr_name, value):
+    """Mirror a (possibly padded) attribute onto hf_config, hf_text_config,
+    and model_config itself when the latter exposes the attribute."""
+    if hasattr(model_config, attr_name):
+        setattr(model_config, attr_name, value)
+    setattr(model_config.hf_config, attr_name, value)
+    setattr(model_config.hf_text_config, attr_name, value)
+
+
 def update_intermediate_size(model_config, attr_name, intermediate_padding_size):
     attr_value = intermediate_padding_size
     if hasattr(model_config, "hf_config") and hasattr(
@@ -83,18 +92,13 @@ def adjust_config_with_unaligned_cpu_tp(
     # Support the case where the num_attention_heads is not divisible by the TP size.
     weight_block_size = may_get_weight_block_size(model_config, load_config)
 
-    model_config.hf_config.original_num_attention_heads = (
-        model_config.num_attention_heads
+    _set_padded_attr(
+        model_config, "original_num_attention_heads", model_config.num_attention_heads
     )
-    model_config.hf_text_config.original_num_attention_heads = (
-        model_config.num_attention_heads
-    )
-
-    model_config.hf_config.original_total_num_kv_heads = (
-        model_config.get_total_num_kv_heads()
-    )
-    model_config.hf_text_config.original_total_num_kv_heads = (
-        model_config.get_total_num_kv_heads()
+    _set_padded_attr(
+        model_config,
+        "original_total_num_kv_heads",
+        model_config.get_total_num_kv_heads(),
     )
 
     total_kv_heads = model_config.get_total_num_kv_heads()
@@ -116,18 +120,14 @@ def adjust_config_with_unaligned_cpu_tp(
             or model_config.num_attention_heads % tp_size != 0
         )
     ):
-        model_config.hf_config.original_o_groups = o_groups
-        model_config.hf_text_config.original_o_groups = o_groups
+        _set_padded_attr(model_config, "original_o_groups", o_groups)
 
         heads_per_group = model_config.num_attention_heads // o_groups
         new_o_groups = ((o_groups + tp_size - 1) // tp_size) * tp_size
         new_num_attention_heads = heads_per_group * new_o_groups
 
-        model_config.hf_config.o_groups = new_o_groups
-        model_config.hf_text_config.o_groups = new_o_groups
-        model_config.num_attention_heads = new_num_attention_heads
-        model_config.hf_config.num_attention_heads = new_num_attention_heads
-        model_config.hf_text_config.num_attention_heads = new_num_attention_heads
+        _set_padded_attr(model_config, "o_groups", new_o_groups)
+        _set_padded_attr(model_config, "num_attention_heads", new_num_attention_heads)
 
     needs_attn_pad = model_config.num_attention_heads % tp_size != 0
     needs_kv_pad = not is_mqa and total_kv_heads % tp_size != 0
@@ -156,6 +156,8 @@ def adjust_config_with_unaligned_cpu_tp(
         pad_size = get_num_heads_padding_size(tp_size, weight_block_size, head_dim)
 
         if is_mqa:
+            # Plain MQA path; grouped-MQA models (with `o_groups`) were already
+            # aligned by the pre-pad above, so they won't reach here.
             # Keep num_key_value_heads == 1 (replicated). Pad attention heads only.
             num_attention_heads = pad_vocab_size(
                 model_config.num_attention_heads, pad_size
@@ -164,15 +166,11 @@ def adjust_config_with_unaligned_cpu_tp(
             query_heads_per_kv = model_config.num_attention_heads // total_kv_heads
             num_key_value_heads = pad_vocab_size(total_kv_heads, pad_size)
 
-            model_config.num_key_value_heads = num_key_value_heads
-            model_config.hf_config.num_key_value_heads = num_key_value_heads
-            model_config.hf_text_config.num_key_value_heads = num_key_value_heads
+            _set_padded_attr(model_config, "num_key_value_heads", num_key_value_heads)
 
             num_attention_heads = num_key_value_heads * query_heads_per_kv
 
-        model_config.num_attention_heads = num_attention_heads
-        model_config.hf_config.num_attention_heads = num_attention_heads
-        model_config.hf_text_config.num_attention_heads = num_attention_heads
+        _set_padded_attr(model_config, "num_attention_heads", num_attention_heads)
 
     intermediate_padding_size = tp_size * get_moe_padding_size(weight_block_size)
     model_config = update_intermediate_size(

--- a/python/sglang/srt/configs/update_config.py
+++ b/python/sglang/srt/configs/update_config.py
@@ -55,8 +55,6 @@ def get_num_heads_padding_size(tp_size, weight_block_size, head_dim):
 
 
 def _set_padded_attr(model_config, attr_name, value):
-    """Mirror a (possibly padded) attribute onto hf_config, hf_text_config,
-    and model_config itself when the latter exposes the attribute."""
     if hasattr(model_config, attr_name):
         setattr(model_config, attr_name, value)
     setattr(model_config.hf_config, attr_name, value)

--- a/python/sglang/srt/configs/update_config.py
+++ b/python/sglang/srt/configs/update_config.py
@@ -101,6 +101,34 @@ def adjust_config_with_unaligned_cpu_tp(
     # MQA models (num_kv_heads == 1) replicate the single KV head across TP ranks,
     # so kv-head padding is not applicable — only attention-head padding is.
     is_mqa = total_kv_heads == 1
+
+    # Grouped-MQA models (e.g. DeepSeek-V4) carry an additional `o_groups` dim
+    # that must also divide tp_size; the heads-per-group ratio must remain
+    # integer, so pad `o_groups` and `num_attention_heads` together.
+    o_groups = getattr(model_config.hf_config, "o_groups", None)
+    if (
+        is_mqa
+        and isinstance(o_groups, int)
+        and o_groups > 0
+        and model_config.num_attention_heads % o_groups == 0
+        and (
+            o_groups % tp_size != 0
+            or model_config.num_attention_heads % tp_size != 0
+        )
+    ):
+        model_config.hf_config.original_o_groups = o_groups
+        model_config.hf_text_config.original_o_groups = o_groups
+
+        heads_per_group = model_config.num_attention_heads // o_groups
+        new_o_groups = ((o_groups + tp_size - 1) // tp_size) * tp_size
+        new_num_attention_heads = heads_per_group * new_o_groups
+
+        model_config.hf_config.o_groups = new_o_groups
+        model_config.hf_text_config.o_groups = new_o_groups
+        model_config.num_attention_heads = new_num_attention_heads
+        model_config.hf_config.num_attention_heads = new_num_attention_heads
+        model_config.hf_text_config.num_attention_heads = new_num_attention_heads
+
     needs_attn_pad = model_config.num_attention_heads % tp_size != 0
     needs_kv_pad = not is_mqa and total_kv_heads % tp_size != 0
 

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -805,6 +805,29 @@ class MQALayer(nn.Module):
                 )
 
         self.attn_sink = nn.Parameter(torch.empty(self.n_heads, dtype=torch.float32))
+
+        # Reuse the CPU-TP padding-aware helper to copy the checkpoint's
+        # (original_n_heads,) into the (possibly padded) param and zero any
+        # tail entries from CPU-TP head padding. shard_size = full param length
+        # since attn_sink is replicated, not sharded.
+        def _attn_sink_weight_loader(
+            param: torch.Tensor, loaded_weight: torch.Tensor
+        ) -> None:
+            from sglang.srt.model_loader.weight_utils import (
+                narrow_padded_param_and_loaded_weight,
+            )
+
+            param_view, loaded_view = narrow_padded_param_and_loaded_weight(
+                param.data,
+                loaded_weight,
+                param_data_start=0,
+                weight_start=0,
+                dim=0,
+                shard_size=param.data.shape[0],
+            )
+            param_view.copy_(loaded_view)
+
+        self.attn_sink.weight_loader = _attn_sink_weight_loader
         self.fuse_wqa_wkv = envs.SGLANG_OPT_FUSE_WQA_WKV.get()
         if self.fuse_wqa_wkv:
             self.wqkv_a = ReplicatedLinear(

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -817,6 +817,8 @@ class MQALayer(nn.Module):
                 narrow_padded_param_and_loaded_weight,
             )
 
+            # for attn_sink, we can set padded place to any finite value. just leverage
+            # the pad to zero path for simplicity
             param_view, loaded_view = narrow_padded_param_and_loaded_weight(
                 param.data,
                 loaded_weight,


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->


## Modifications
Pad `o_groups` if not divisible by `tp_size`
Add a weight load for `attn_sink` to zero out the padded position

## Benchmark
gsm8k accuracy
TP=3: 0.960
TP=6: 0.975