### PR TITLE
Add fp8_paged_mqa_logits_cpu kernel

### DIFF
--- a/python/sglang/srt/layers/attention/compressed/indexer.py
+++ b/python/sglang/srt/layers/attention/compressed/indexer.py
@@ -157,6 +157,27 @@ def fp8_paged_mqa_logits_torch(
     return logits
 
 
+def fp8_paged_mqa_logits_cpu(
+    q_fp8: torch.Tensor,
+    kvcache_fp8: torch.Tensor,
+    weight: torch.Tensor,
+    seq_lens: torch.Tensor,
+    page_table: torch.Tensor,
+    deep_gemm_metadata: Any,
+    max_seq_len: int,
+    clean_logits: bool = True,
+) -> torch.Tensor:
+    return torch.ops.sgl_kernel.fp8_paged_mqa_logits_cpu(
+        q_fp8,
+        kvcache_fp8,
+        weight,
+        seq_lens,
+        page_table,
+        max_seq_len,
+        clean_logits,
+    )
+
+
 def topk_transform_512_pytorch_vectorized(
     scores: torch.Tensor,
     seq_lens: torch.Tensor,
@@ -478,6 +499,8 @@ class C4IndexerBackend:
             )
         elif envs.SGLANG_FP8_PAGED_MQA_LOGITS_TORCH.get():
             fn = fp8_paged_mqa_logits_torch
+        elif _is_cpu_amx_available:
+            fn = fp8_paged_mqa_logits_cpu
         else:
             if envs.SGLANG_OPT_DG_PAGED_MQA_LOGITS_CHUNK_SIZE.get() != -1:
                 from sglang.srt.layers.deep_gemm_wrapper.paged_mqa_logits import (

--- a/python/sglang/srt/layers/attention/compressed/metadata.py
+++ b/python/sglang/srt/layers/attention/compressed/metadata.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, List, Optional
 import torch
 
 from sglang.srt.environ import envs
-from sglang.srt.utils import is_hip
+from sglang.srt.utils import cpu_has_amx_support, is_cpu, is_hip
 
 if TYPE_CHECKING:
     from flash_mla.flash_mla_interface import FlashMLASchedMeta
@@ -122,7 +122,9 @@ class PagedIndexerMetadata(IndexerMetadata):
     topk_metadata: torch.Tensor = field(init=False, repr=False)
 
     def __post_init__(self):
-        if envs.SGLANG_FP8_PAGED_MQA_LOGITS_TORCH.get():
+        if envs.SGLANG_FP8_PAGED_MQA_LOGITS_TORCH.get() or (
+            is_cpu() and cpu_has_amx_support()
+        ):
             self.deep_gemm_metadata = None
         else:
             import deep_gemm

--- a/sgl-kernel/csrc/cpu/paged_mqa_logits.cpp
+++ b/sgl-kernel/csrc/cpu/paged_mqa_logits.cpp
@@ -4,7 +4,6 @@
 #include "vec.h"
 
 #include <algorithm>
-#include <array>
 #include <cstdint>
 
 namespace {
@@ -29,35 +28,15 @@ inline float dot_fp8_128_scalar(const uint8_t* k, const uint8_t* q) {
   return dot;
 }
 
-inline const float* fp8_e4m3_to_float_lut() {
-  static const std::array<float, 256> lut = [] {
-    std::array<float, 256> values{};
-    for (int i = 0; i < 256; ++i) {
-      values[i] = fp8_e4m3_to_float(static_cast<uint8_t>(i));
-    }
-    return values;
-  }();
-  return lut.data();
-}
-
 #if defined(CPU_CAPABILITY_AVX512)
 inline float dot_fp8_128(const uint8_t* k, const uint8_t* q) {
-  using fVec = at::vec::Vectorized<float>;
-
-  const float* lut = fp8_e4m3_to_float_lut();
-  fVec acc(0.0f);
-
-  for (int64_t d = 0; d < kHeadDim; d += 16) {
-    const __m128i k_fp8 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(k + d));
-    const __m128i q_fp8 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(q + d));
-    const __m512i k_idx = _mm512_cvtepu8_epi32(k_fp8);
-    const __m512i q_idx = _mm512_cvtepu8_epi32(q_fp8);
-    const fVec k_val(_mm512_i32gather_ps(k_idx, lut, sizeof(float)));
-    const fVec q_val(_mm512_i32gather_ps(q_idx, lut, sizeof(float)));
-    acc = k_val * q_val + acc;
+  __m512 acc = _mm512_setzero_ps();
+  for (int64_t d = 0; d < kHeadDim; d += 32) {
+    const __m256i k8 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(k + d));
+    const __m256i q8 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(q + d));
+    acc = _mm512_dpbf16_ps(acc, CVT_FP8_TO_BF16(k8), CVT_FP8_TO_BF16(q8));
   }
-
-  return vec_reduce_sum(acc);
+  return _mm512_reduce_add_ps(acc);
 }
 #else
 inline float dot_fp8_128(const uint8_t* k, const uint8_t* q) {

--- a/sgl-kernel/csrc/cpu/paged_mqa_logits.cpp
+++ b/sgl-kernel/csrc/cpu/paged_mqa_logits.cpp
@@ -173,6 +173,7 @@ at::Tensor fp8_paged_mqa_logits_cpu(
   TORCH_CHECK(q_fp8.scalar_type() == at::ScalarType::Float8_e4m3fn, "q_fp8 must be torch.float8_e4m3fn");
   TORCH_CHECK(kvcache_fp8.scalar_type() == at::kByte, "kvcache_fp8 must be torch.uint8 storage");
 
+  // The checks are aligned with fp8_paged_mqa_logits_torch in indexer.py.
   TORCH_CHECK(q_fp8.dim() == 4, "q_fp8 must have shape [batch, 1, heads, 128]");
   TORCH_CHECK(q_fp8.size(1) == 1, "q_fp8 second dimension must be 1");
   TORCH_CHECK(q_fp8.size(3) == kHeadDim, "q_fp8 head_dim must be 128");

--- a/sgl-kernel/csrc/cpu/paged_mqa_logits.cpp
+++ b/sgl-kernel/csrc/cpu/paged_mqa_logits.cpp
@@ -1,0 +1,223 @@
+#include <c10/util/Float8_e4m3fn.h>
+
+#include "common.h"
+#include "vec.h"
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+
+namespace {
+
+constexpr int64_t kBlockSize = 64;
+constexpr int64_t kHeadDim = 128;
+constexpr int64_t kHeadDimWithScaleBytes = 132;
+constexpr int64_t kScaleOffsetBytes = kBlockSize * kHeadDim;
+constexpr int64_t kBlockBytes = kBlockSize * kHeadDimWithScaleBytes;
+
+inline float fp8_e4m3_to_float(uint8_t v) {
+  c10::Float8_e4m3fn x;
+  x.x = v;
+  return static_cast<float>(x);
+}
+
+inline float dot_fp8_128_scalar(const uint8_t* k, const uint8_t* q) {
+  float dot = 0.0f;
+  for (int64_t d = 0; d < kHeadDim; ++d) {
+    dot += fp8_e4m3_to_float(k[d]) * fp8_e4m3_to_float(q[d]);
+  }
+  return dot;
+}
+
+inline const float* fp8_e4m3_to_float_lut() {
+  static const std::array<float, 256> lut = [] {
+    std::array<float, 256> values{};
+    for (int i = 0; i < 256; ++i) {
+      values[i] = fp8_e4m3_to_float(static_cast<uint8_t>(i));
+    }
+    return values;
+  }();
+  return lut.data();
+}
+
+#if defined(CPU_CAPABILITY_AVX512)
+inline float dot_fp8_128(const uint8_t* k, const uint8_t* q) {
+  using fVec = at::vec::Vectorized<float>;
+
+  const float* lut = fp8_e4m3_to_float_lut();
+  fVec acc(0.0f);
+
+  for (int64_t d = 0; d < kHeadDim; d += 16) {
+    const __m128i k_fp8 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(k + d));
+    const __m128i q_fp8 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(q + d));
+    const __m512i k_idx = _mm512_cvtepu8_epi32(k_fp8);
+    const __m512i q_idx = _mm512_cvtepu8_epi32(q_fp8);
+    const fVec k_val(_mm512_i32gather_ps(k_idx, lut, sizeof(float)));
+    const fVec q_val(_mm512_i32gather_ps(q_idx, lut, sizeof(float)));
+    acc = k_val * q_val + acc;
+  }
+
+  return vec_reduce_sum(acc);
+}
+#else
+inline float dot_fp8_128(const uint8_t* k, const uint8_t* q) {
+  return dot_fp8_128_scalar(k, q);
+}
+#endif
+
+template <typename T>
+inline int64_t load_int(const T* ptr, int64_t idx) {
+  return static_cast<int64_t>(ptr[idx]);
+}
+
+template <typename T>
+inline float load_weight(const T* ptr, int64_t idx) {
+  return static_cast<float>(ptr[idx]);
+}
+
+template <typename seq_t, typename page_t, typename weight_t>
+void fp8_paged_mqa_logits_cpu_impl(
+    const at::Tensor& q_fp8,
+    const at::Tensor& kvcache_fp8,
+    const at::Tensor& weight,
+    const at::Tensor& seq_lens,
+    const at::Tensor& page_table,
+    at::Tensor& logits,
+    int64_t max_seq_len) {
+  const int64_t batch_size = q_fp8.size(0);
+  const int64_t num_heads = q_fp8.size(2);
+  const int64_t num_blocks = kvcache_fp8.size(0);
+  const int64_t pages_per_batch = page_table.size(1);
+
+  const auto* q_ptr = reinterpret_cast<const uint8_t*>(q_fp8.const_data_ptr());
+  const auto* cache_ptr = reinterpret_cast<const uint8_t*>(kvcache_fp8.const_data_ptr());
+  const auto* weight_ptr = weight.const_data_ptr<weight_t>();
+  const auto* seq_ptr = seq_lens.const_data_ptr<seq_t>();
+  const auto* page_ptr = page_table.const_data_ptr<page_t>();
+  auto* out_ptr = logits.data_ptr<float>();
+
+  at::parallel_for(0, batch_size * max_seq_len, GRAIN_SIZE / kHeadDim, [&](int64_t begin, int64_t end) {
+    int64_t b{0}, token{0};
+    data_index_init(begin, b, batch_size, token, max_seq_len);
+    for (int64_t i = begin; i < end; ++i) {
+      const int64_t seq_len = load_int(seq_ptr, b);
+      TORCH_CHECK(seq_len >= 0 && seq_len <= max_seq_len, "seq_lens must be in [0, max_seq_len]");
+
+      if (token >= seq_len) {
+        data_index_step(b, batch_size, token, max_seq_len);
+        continue;
+      }
+
+      const int64_t q_batch_offset = ((b * 1 * num_heads) * kHeadDim);
+      const int64_t weight_batch_offset = b * num_heads;
+      const int64_t page_batch_offset = b * pages_per_batch;
+      float* out_row = out_ptr + b * max_seq_len;
+
+      const int64_t logical_page = token / kBlockSize;
+      const int64_t token_in_page = token % kBlockSize;
+      TORCH_CHECK(logical_page < pages_per_batch, "page_table does not cover seq_len");
+
+      const int64_t physical_page = load_int(page_ptr, page_batch_offset + logical_page);
+      TORCH_CHECK(physical_page >= 0 && physical_page < num_blocks, "page_table contains an invalid page index");
+
+      const uint8_t* block = cache_ptr + physical_page * kBlockBytes;
+      const uint8_t* k_token = block + token_in_page * kHeadDim;
+      const float* scale_ptr = reinterpret_cast<const float*>(block + kScaleOffsetBytes);
+      const float k_scale = scale_ptr[token_in_page];
+
+      float score_sum = 0.0f;
+      for (int64_t h = 0; h < num_heads; ++h) {
+        const uint8_t* q_head = q_ptr + q_batch_offset + h * kHeadDim;
+        float dot = dot_fp8_128(k_token, q_head);
+        dot = std::max(dot, 0.0f);
+        score_sum += dot * load_weight(weight_ptr, weight_batch_offset + h);
+      }
+
+      out_row[token] = score_sum * k_scale;
+
+      data_index_step(b, batch_size, token, max_seq_len);
+    }
+  });
+}
+
+template <typename seq_t, typename page_t>
+void dispatch_weight_type(
+    const at::Tensor& q_fp8,
+    const at::Tensor& kvcache_fp8,
+    const at::Tensor& weight,
+    const at::Tensor& seq_lens,
+    const at::Tensor& page_table,
+    at::Tensor& logits,
+    int64_t max_seq_len) {
+  AT_DISPATCH_FLOATING_TYPES_AND2(
+      at::ScalarType::Half, at::ScalarType::BFloat16, weight.scalar_type(), "fp8_paged_mqa_logits_cpu_weight", [&] {
+        fp8_paged_mqa_logits_cpu_impl<seq_t, page_t, scalar_t>(
+            q_fp8, kvcache_fp8, weight, seq_lens, page_table, logits, max_seq_len);
+      });
+}
+
+template <typename seq_t>
+void dispatch_page_type(
+    const at::Tensor& q_fp8,
+    const at::Tensor& kvcache_fp8,
+    const at::Tensor& weight,
+    const at::Tensor& seq_lens,
+    const at::Tensor& page_table,
+    at::Tensor& logits,
+    int64_t max_seq_len) {
+  if (page_table.scalar_type() == at::kInt) {
+    dispatch_weight_type<seq_t, int32_t>(q_fp8, kvcache_fp8, weight, seq_lens, page_table, logits, max_seq_len);
+  } else if (page_table.scalar_type() == at::kLong) {
+    dispatch_weight_type<seq_t, int64_t>(q_fp8, kvcache_fp8, weight, seq_lens, page_table, logits, max_seq_len);
+  } else {
+    TORCH_CHECK(false, "page_table must be int32 or int64");
+  }
+}
+
+}  // namespace
+
+at::Tensor fp8_paged_mqa_logits_cpu(
+    at::Tensor& q_fp8,
+    at::Tensor& kvcache_fp8,
+    at::Tensor& weight,
+    at::Tensor& seq_lens,
+    at::Tensor& page_table,
+    int64_t max_seq_len,
+    bool clean_logits) {
+  RECORD_FUNCTION("sgl-kernel::fp8_paged_mqa_logits_cpu", std::vector<c10::IValue>({q_fp8, kvcache_fp8, weight}));
+  TORCH_CHECK(!clean_logits, "fp8_paged_mqa_logits_cpu only supports clean_logits == false");
+  CHECK_INPUT(q_fp8);
+  CHECK_INPUT(kvcache_fp8);
+  CHECK_INPUT(weight);
+  CHECK_INPUT(seq_lens);
+  CHECK_INPUT(page_table);
+  TORCH_CHECK(q_fp8.scalar_type() == at::ScalarType::Float8_e4m3fn, "q_fp8 must be torch.float8_e4m3fn");
+  TORCH_CHECK(kvcache_fp8.scalar_type() == at::kByte, "kvcache_fp8 must be torch.uint8 storage");
+
+  TORCH_CHECK(q_fp8.dim() == 4, "q_fp8 must have shape [batch, 1, heads, 128]");
+  TORCH_CHECK(q_fp8.size(1) == 1, "q_fp8 second dimension must be 1");
+  TORCH_CHECK(q_fp8.size(3) == kHeadDim, "q_fp8 head_dim must be 128");
+  TORCH_CHECK(kvcache_fp8.dim() == 4, "kvcache_fp8 must have shape [blocks, 64, 1, 132]");
+  TORCH_CHECK(kvcache_fp8.size(1) == kBlockSize, "kvcache_fp8 block size must be 64");
+  TORCH_CHECK(kvcache_fp8.size(2) == 1, "kvcache_fp8 num kv heads must be 1");
+  TORCH_CHECK(kvcache_fp8.size(3) == kHeadDimWithScaleBytes, "kvcache_fp8 last dimension must be 132 bytes");
+
+  const int64_t batch_size = q_fp8.size(0);
+  const int64_t num_heads = q_fp8.size(2);
+  TORCH_CHECK(weight.sizes() == at::IntArrayRef({batch_size, num_heads}), "weight must have shape [batch, heads]");
+  TORCH_CHECK(seq_lens.sizes() == at::IntArrayRef({batch_size}), "seq_lens must have shape [batch]");
+  TORCH_CHECK(page_table.dim() == 2 && page_table.size(0) == batch_size, "page_table must have shape [batch, pages]");
+  TORCH_CHECK(max_seq_len >= 0, "max_seq_len must be non-negative");
+
+  auto logits = at::empty({batch_size, max_seq_len}, q_fp8.options().dtype(at::kFloat));
+
+  if (seq_lens.scalar_type() == at::kInt) {
+    dispatch_page_type<int32_t>(q_fp8, kvcache_fp8, weight, seq_lens, page_table, logits, max_seq_len);
+  } else if (seq_lens.scalar_type() == at::kLong) {
+    dispatch_page_type<int64_t>(q_fp8, kvcache_fp8, weight, seq_lens, page_table, logits, max_seq_len);
+  } else {
+    TORCH_CHECK(false, "seq_lens must be int32 or int64");
+  }
+
+  return logits;
+}

--- a/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
+++ b/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
@@ -105,6 +105,15 @@ void topk_transform_512_cpu(
     int64_t page_size,
     const std::optional<at::Tensor>& out_raw_indices);
 
+at::Tensor fp8_paged_mqa_logits_cpu(
+    at::Tensor& q_fp8,
+    at::Tensor& kvcache_fp8,
+    at::Tensor& weight,
+    at::Tensor& seq_lens,
+    at::Tensor& page_table,
+    int64_t max_seq_len,
+    bool clean_logits);
+
 // attention
 void decode_attention_cpu(
     at::Tensor& query,
@@ -453,6 +462,12 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "topk_transform_512_cpu(Tensor scores, Tensor seq_lens, Tensor page_tables, Tensor(a!) out_page_indices, "
       "int page_size, Tensor(a!)? out_raw_indices) -> ()");
   m.impl("topk_transform_512_cpu", torch::kCPU, &topk_transform_512_cpu);
+
+  // DeepSeek V4 compressed attention FP8 paged MQA logits
+  m.def(
+      "fp8_paged_mqa_logits_cpu(Tensor q_fp8, Tensor kvcache_fp8, Tensor weight, Tensor seq_lens, "
+      "Tensor page_table, int max_seq_len, bool clean_logits) -> Tensor");
+  m.impl("fp8_paged_mqa_logits_cpu", torch::kCPU, &fp8_paged_mqa_logits_cpu);
 
   // decode
   m.def(

--- a/test/srt/cpu/test_fp8_paged_mqa_logits_cpu.py
+++ b/test/srt/cpu/test_fp8_paged_mqa_logits_cpu.py
@@ -1,0 +1,106 @@
+import unittest
+
+import torch
+
+import sgl_kernel  # noqa: F401
+from sglang.srt.layers.attention.compressed.indexer import (
+    fp8_paged_mqa_logits_torch,
+)
+from sglang.test.test_utils import CustomTestCase
+
+
+BLOCK_SIZE = 64
+HEAD_DIM = 128
+HEAD_DIM_WITH_SCALE_BYTES = 132
+
+
+class TestFp8PagedMqaLogitsCPU(CustomTestCase):
+    def _make_inputs(
+        self,
+        *,
+        batch_size: int = 3,
+        num_heads: int = 4,
+        max_seq_len: int = 192,
+        num_blocks: int = 8,
+        index_dtype: torch.dtype = torch.int32,
+        weight_dtype: torch.dtype = torch.float32,
+    ):
+        torch.manual_seed(0)
+
+        q = torch.randn(batch_size, 1, num_heads, HEAD_DIM, dtype=torch.float32) * 0.25
+        q_fp8 = q.to(torch.float8_e4m3fn).contiguous()
+
+        k = torch.randn(num_blocks, BLOCK_SIZE, HEAD_DIM, dtype=torch.float32) * 0.25
+        k_fp8 = k.to(torch.float8_e4m3fn).contiguous()
+        k_bytes = k_fp8.view(num_blocks, BLOCK_SIZE * HEAD_DIM).view(dtype=torch.uint8)
+
+        scales = torch.rand(num_blocks, BLOCK_SIZE, dtype=torch.float32) * 0.5 + 0.75
+        scale_bytes = scales.contiguous().view(num_blocks, BLOCK_SIZE).view(dtype=torch.uint8)
+
+        kvcache = torch.cat([k_bytes, scale_bytes], dim=1).contiguous()
+        kvcache = kvcache.view(num_blocks, BLOCK_SIZE, 1, HEAD_DIM_WITH_SCALE_BYTES)
+
+        weight = torch.randn(batch_size, num_heads, dtype=torch.float32).to(weight_dtype).contiguous()
+        seq_lens = torch.tensor([0, 65, max_seq_len - 1], dtype=index_dtype)
+
+        pages_per_batch = (max_seq_len + BLOCK_SIZE - 1) // BLOCK_SIZE
+        page_table = torch.empty(batch_size, pages_per_batch, dtype=index_dtype)
+        page_table[0] = torch.tensor([0, 1, 2], dtype=index_dtype)
+        page_table[1] = torch.tensor([3, 4, 5], dtype=index_dtype)
+        page_table[2] = torch.tensor([2, 6, 7], dtype=index_dtype)
+
+        return q_fp8, kvcache, weight, seq_lens, page_table, max_seq_len
+
+    def _assert_matches_reference(self, index_dtype: torch.dtype, weight_dtype: torch.dtype):
+        q_fp8, kvcache, weight, seq_lens, page_table, max_seq_len = self._make_inputs(
+            index_dtype=index_dtype,
+            weight_dtype=weight_dtype,
+        )
+
+        actual = torch.ops.sgl_kernel.fp8_paged_mqa_logits_cpu(
+            q_fp8,
+            kvcache,
+            weight,
+            seq_lens,
+            page_table,
+            max_seq_len,
+            False,
+        )
+        expected = fp8_paged_mqa_logits_torch(
+            q_fp8,
+            kvcache,
+            weight,
+            seq_lens,
+            page_table,
+            None,
+            max_seq_len,
+            False,
+        )
+
+        self.assertEqual(actual.shape, (seq_lens.numel(), max_seq_len))
+        self.assertEqual(actual.dtype, torch.float32)
+        for batch_idx, seq_len in enumerate(seq_lens.tolist()):
+            if seq_len == 0:
+                continue
+            torch.testing.assert_close(
+                actual[batch_idx, :seq_len],
+                expected[batch_idx, :seq_len],
+                rtol=1e-5,
+                atol=1e-5,
+            )
+
+    @unittest.skipIf(
+        not hasattr(torch, "float8_e4m3fn"), "torch.float8_e4m3fn is unavailable"
+    )
+    def test_matches_torch_reference_int32_float32(self):
+        self._assert_matches_reference(torch.int32, torch.float32)
+
+    @unittest.skipIf(
+        not hasattr(torch, "float8_e4m3fn"), "torch.float8_e4m3fn is unavailable"
+    )
+    def test_matches_torch_reference_int64_bfloat16(self):
+        self._assert_matches_reference(torch.int64, torch.bfloat16)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/cpu/test_fp8_paged_mqa_logits_cpu.py
+++ b/test/srt/cpu/test_fp8_paged_mqa_logits_cpu.py
@@ -99,17 +99,12 @@ class TestFp8PagedMqaLogitsCPU(CustomTestCase):
                 rtol=rtol,
             )
 
-    @unittest.skipIf(
-        not hasattr(torch, "float8_e4m3fn"), "torch.float8_e4m3fn is unavailable"
-    )
-    def test_matches_torch_reference_int32_float32(self):
-        self._assert_matches_reference(torch.int32, torch.float32)
-
-    @unittest.skipIf(
-        not hasattr(torch, "float8_e4m3fn"), "torch.float8_e4m3fn is unavailable"
-    )
-    def test_matches_torch_reference_int64_bfloat16(self):
-        self._assert_matches_reference(torch.int64, torch.bfloat16)
+    def test_matches_torch_reference(self):
+        self._assert_matches_reference(
+            index_dtype=torch.int32,
+            weight_dtype=torch.float32,
+            q_dtype=torch.bfloat16,
+        )
 
 
 if __name__ == "__main__":

--- a/test/srt/cpu/test_fp8_paged_mqa_logits_cpu.py
+++ b/test/srt/cpu/test_fp8_paged_mqa_logits_cpu.py
@@ -8,6 +8,8 @@ from sglang.srt.layers.attention.compressed.indexer import (
 )
 from sglang.test.test_utils import CustomTestCase
 
+from utils import precision
+
 
 BLOCK_SIZE = 64
 HEAD_DIM = 128
@@ -24,13 +26,14 @@ class TestFp8PagedMqaLogitsCPU(CustomTestCase):
         num_blocks: int = 8,
         index_dtype: torch.dtype = torch.int32,
         weight_dtype: torch.dtype = torch.float32,
+        q_dtype: torch.dtype = torch.bfloat16,
     ):
-        torch.manual_seed(0)
+        torch.manual_seed(2)
 
-        q = torch.randn(batch_size, 1, num_heads, HEAD_DIM, dtype=torch.float32) * 0.25
+        q = (torch.randn(batch_size, 1, num_heads, HEAD_DIM) * 0.25).to(q_dtype)
         q_fp8 = q.to(torch.float8_e4m3fn).contiguous()
 
-        k = torch.randn(num_blocks, BLOCK_SIZE, HEAD_DIM, dtype=torch.float32) * 0.25
+        k = (torch.randn(num_blocks, BLOCK_SIZE, HEAD_DIM) * 0.25).to(q_dtype)
         k_fp8 = k.to(torch.float8_e4m3fn).contiguous()
         k_bytes = k_fp8.view(num_blocks, BLOCK_SIZE * HEAD_DIM).view(dtype=torch.uint8)
 
@@ -51,10 +54,16 @@ class TestFp8PagedMqaLogitsCPU(CustomTestCase):
 
         return q_fp8, kvcache, weight, seq_lens, page_table, max_seq_len
 
-    def _assert_matches_reference(self, index_dtype: torch.dtype, weight_dtype: torch.dtype):
+    def _assert_matches_reference(
+        self,
+        index_dtype: torch.dtype,
+        weight_dtype: torch.dtype,
+        q_dtype: torch.dtype = torch.bfloat16,
+    ):
         q_fp8, kvcache, weight, seq_lens, page_table, max_seq_len = self._make_inputs(
             index_dtype=index_dtype,
             weight_dtype=weight_dtype,
+            q_dtype=q_dtype,
         )
 
         actual = torch.ops.sgl_kernel.fp8_paged_mqa_logits_cpu(
@@ -79,14 +88,15 @@ class TestFp8PagedMqaLogitsCPU(CustomTestCase):
 
         self.assertEqual(actual.shape, (seq_lens.numel(), max_seq_len))
         self.assertEqual(actual.dtype, torch.float32)
+        atol = rtol = precision[q_dtype]
         for batch_idx, seq_len in enumerate(seq_lens.tolist()):
             if seq_len == 0:
                 continue
             torch.testing.assert_close(
                 actual[batch_idx, :seq_len],
                 expected[batch_idx, :seq_len],
-                rtol=1e-5,
-                atol=1e-5,
+                atol=atol,
+                rtol=rtol,
             )
 
     @unittest.skipIf(


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Modifications
Add fp8_paged_mqa_logits_cpu kernel to replace fp8_paged_mqa_logits_torch.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Benchmark
You need to remove SGLANG_FP8_PAGED_MQA_LOGITS_TORCH=1 from the command line to use this kernel.

### Accuracy
gsm8k Accuracy: 0.965

### Performance
TP=2, 40 cores per rank

bs=1, input=256, output=16
30% speedup for TTFT
3% speedup for TPOT

bs=1, input=1024, output=64
40% speedup for TTFT
No obvious change for TPOT
