### PR TITLE
add kernel for hadamard_transform_cpu, set_k_and_s_cpu, and quant_to_nope_fp8_rope_bf16_pack_cpu

### DIFF
--- a/python/sglang/srt/layers/attention/nsa/index_buf_accessor_v4.py
+++ b/python/sglang/srt/layers/attention/nsa/index_buf_accessor_v4.py
@@ -8,9 +8,11 @@ import triton
 import triton.language as tl
 
 from sglang.srt.layers.quantization.fp8_kernel import is_fp8_fnuz
-
+from sglang.srt.utils import cpu_has_amx_support, is_cpu
 fp8_dtype = torch.float8_e4m3fnuz if is_fp8_fnuz() else torch.float8_e4m3fn
 
+_is_cpu = is_cpu()
+_is_cpu_amx_available = cpu_has_amx_support()
 
 @dataclass
 class NopeFp8RopeBf16Pack:
@@ -41,7 +43,10 @@ class SetKAndS:
 
     @classmethod
     def torch(cls, pool, buf, loc, nope_fp8_rope_bf16_pack: NopeFp8RopeBf16Pack):
-        _set_k_and_s_torch(buf, loc, nope_fp8_rope_bf16_pack, pool.page_size)
+        if _is_cpu and _is_cpu_amx_available:
+            torch.ops.sgl_kernel.set_k_and_s_cpu(buf, loc, nope_fp8_rope_bf16_pack.k_nope_fp8, nope_fp8_rope_bf16_pack.k_rope_bf16, nope_fp8_rope_bf16_pack.scale_k_nope_ue8m0, pool.page_size)
+        else:
+            _set_k_and_s_torch(buf, loc, nope_fp8_rope_bf16_pack, pool.page_size)
 
     @classmethod
     def triton(cls, pool, buf, loc, nope_fp8_rope_bf16_pack: NopeFp8RopeBf16Pack):

--- a/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
+++ b/python/sglang/srt/layers/attention/nsa/nsa_indexer.py
@@ -11,6 +11,7 @@ from sglang.srt.layers.layernorm import LayerNorm
 from sglang.srt.layers.quantization.fp8_kernel import is_fp8_fnuz
 from sglang.srt.layers.utils import MultiPlatformOp
 from sglang.srt.utils import (
+    cpu_has_amx_support,
     add_prefix,
     ceil_align,
     get_device_sm,
@@ -23,6 +24,7 @@ from sglang.srt.utils import (
 
 global _use_multi_stream
 _is_cuda = is_cuda()
+_is_cpu_amx_available = cpu_has_amx_support()
 _is_hip = is_hip()
 _is_sm103 = _is_cuda and get_device_sm() == 103
 _is_npu = is_npu()
@@ -149,7 +151,9 @@ def _torch_hadamard_transform(x: torch.Tensor, scale: float) -> torch.Tensor:
 def rotate_activation(x: torch.Tensor) -> torch.Tensor:
     if _is_hip or _is_sm103:
         from fast_hadamard_transform import hadamard_transform
-    elif _is_xpu or _is_cpu:
+    elif _is_cpu and _is_cpu_amx_available:
+        hadamard_transform = torch.ops.sgl_kernel.fast_hadamard_transform_cpu
+    elif _is_xpu:
         hadamard_transform = _torch_hadamard_transform
     else:
         try:

--- a/python/sglang/srt/layers/attention/nsa/quant_k_cache_v4.py
+++ b/python/sglang/srt/layers/attention/nsa/quant_k_cache_v4.py
@@ -4,9 +4,10 @@ import triton.language as tl
 
 from sglang.srt.layers.attention.nsa.index_buf_accessor_v4 import NopeFp8RopeBf16Pack
 from sglang.srt.layers.quantization.fp8_kernel import is_fp8_fnuz
-
+from sglang.srt.utils import cpu_has_amx_support, is_cpu
 fp8_dtype = torch.float8_e4m3fnuz if is_fp8_fnuz() else torch.float8_e4m3fn
-
+_is_cpu = is_cpu()
+_is_cpu_amx_available = cpu_has_amx_support()
 
 @triton.jit
 def _quant_k_cache_fused_kernel(
@@ -121,6 +122,9 @@ def quant_to_nope_fp8_rope_bf16_pack_triton(
 
 
 def quant_to_nope_fp8_rope_bf16_pack(k_bf16: torch.Tensor) -> NopeFp8RopeBf16Pack:
+    if _is_cpu and _is_cpu_amx_available:
+        return NopeFp8RopeBf16Pack(*torch.ops.sgl_kernel.quant_to_nope_fp8_rope_bf16_pack_cpu(k_bf16))
+
     assert k_bf16.dtype == torch.bfloat16
     _num_tokens, hidden_dim = k_bf16.shape
     assert hidden_dim == 512

--- a/sgl-kernel/csrc/cpu/common.h
+++ b/sgl-kernel/csrc/cpu/common.h
@@ -74,6 +74,28 @@ namespace {
     }                                                            \
   }()
 
+// dispatch: float, bfloat16, float16
+#define CPU_DISPATCH_FLOATING_TYPES(TYPE, NAME, ...)              \
+  [&] {                                                          \
+    switch (TYPE) {                                              \
+      case at::ScalarType::Float: {                              \
+        using scalar_t = float;                                  \
+        return __VA_ARGS__();                                    \
+      }                                                          \
+      case at::ScalarType::BFloat16: {                           \
+        using scalar_t = at::BFloat16;                           \
+        return __VA_ARGS__();                                    \
+      }                                                          \
+      case at::ScalarType::Half: {                               \
+        using scalar_t = at::Half;                               \
+        return __VA_ARGS__();                                    \
+      }                                                          \
+      default:                                                   \
+        TORCH_CHECK(false, NAME, ": unsupported dtype ",         \
+                    toString(TYPE));                              \
+    }                                                            \
+  }()
+
 // Helper MICRO for CPU_DISPATCH_FLOATING_TYPES_EXT:
 //   TYPE1: the primary dtype (input, output, weight);
 //   TYPE2: defined as PARAM_T input

--- a/sgl-kernel/csrc/cpu/hadamard.cpp
+++ b/sgl-kernel/csrc/cpu/hadamard.cpp
@@ -171,7 +171,7 @@ void fast_hadamard_transform_kernel_impl(
     int64_t rows,
     int64_t n,
     float scale) {
-  at::parallel_for(0, rows, 1, [&](int64_t begin, int64_t end) {
+  at::parallel_for(0, rows, 0, [&](int64_t begin, int64_t end) {
     float* buf = nullptr;
     std::vector<float> scratch;
     if constexpr (!std::is_same_v<scalar_t, float>) {

--- a/sgl-kernel/csrc/cpu/hadamard.cpp
+++ b/sgl-kernel/csrc/cpu/hadamard.cpp
@@ -1,0 +1,160 @@
+#include "common.h"
+#include "vec.h"
+
+namespace {
+
+// ──────────────────────────────────────────────────────────────────────
+// Iterative Cooley-Tukey-style Fast Walsh-Hadamard Transform (FWHT)
+// along the last dimension.  n must be a power of two.
+//
+// For each row of length n the butterfly loop is:
+//   for h = 1, 2, 4, …, n/2
+//     for every pair (a[j], b[j]) separated by stride h
+//       (a[j], b[j]) ← (a[j]+b[j], a[j]−b[j])
+//
+// When h >= 16 (== 512-bit / sizeof(float)) we can do the butterfly
+// entirely with AVX-512 loads/stores.  The inner two cases (h < 16)
+// use in-register shuffles so we never spill to memory at small
+// strides.
+// ──────────────────────────────────────────────────────────────────────
+
+// Scalar fallback for a single row of length n
+inline void fwht_row_scalar(float* __restrict__ row, int64_t n, float scale) {
+  for (int64_t h = 1; h < n; h <<= 1) {
+    for (int64_t j = 0; j < n; j += 2 * h) {
+      for (int64_t k = 0; k < h; ++k) {
+        float a = row[j + k];
+        float b = row[j + k + h];
+        row[j + k]     = a + b;
+        row[j + k + h] = a - b;
+      }
+    }
+  }
+  for (int64_t d = 0; d < n; ++d) {
+    row[d] *= scale;
+  }
+}
+
+#if defined(CPU_CAPABILITY_AVX512)
+
+// AVX-512 optimized FWHT for a single row of length n (power of 2, n >= 16)
+inline void fwht_row_avx512(float* __restrict__ row, int64_t n, float scale) {
+  // For small strides (h < 16), we process 16 floats at a time using
+  // in-register shuffles to do butterflies without extra loads/stores.
+  // For h >= 16, we do standard load-butterfly-store with AVX-512.
+
+  // Phase 1: h = 1, 2, 4, 8 — in-register butterflies
+  // Process the row in chunks of 16 floats.
+  // For h=1: butterfly pairs at stride 1 within each 16-float chunk.
+  // For h=2: butterfly pairs at stride 2 within each 16-float chunk.
+  // etc.
+
+  for (int64_t h = 1; h < 16 && h < n; h <<= 1) {
+    for (int64_t j = 0; j < n; j += 16) {
+      __m512 v = _mm512_loadu_ps(row + j);
+
+      // Shuffle to get the paired element.
+      // For stride h, element i is paired with element i^h.
+      // We need to swap elements that differ in bit position log2(h).
+      __m512 paired;
+      if (h == 1) {
+        // swap adjacent: 0↔1, 2↔3, 4↔5, …
+        paired = _mm512_permute_ps(v, 0b10'11'00'01);
+      } else if (h == 2) {
+        // swap pairs: (0,1)↔(2,3), (4,5)↔(6,7), …
+        paired = _mm512_permute_ps(v, 0b01'00'11'10);
+      } else if (h == 4) {
+        // swap quads: (0..3)↔(4..7) within each 256-bit half
+        paired = _mm512_permutexvar_ps(
+            _mm512_set_epi32(11, 10, 9, 8, 15, 14, 13, 12, 3, 2, 1, 0, 7, 6, 5, 4), v);
+      } else {  // h == 8
+        // swap octets: (0..7)↔(8..15)
+        paired = _mm512_permutexvar_ps(
+            _mm512_set_epi32(7, 6, 5, 4, 3, 2, 1, 0, 15, 14, 13, 12, 11, 10, 9, 8), v);
+      }
+
+      // For the "first" slot (bit log2(h) == 0): v[i]=a, paired[i]=b → sum = a+b
+      // For the "second" slot (bit log2(h) == 1): v[i]=b, paired[i]=a → diff = a-b
+      __m512 sum  = _mm512_add_ps(v, paired);
+      __m512 diff = _mm512_sub_ps(paired, v);  // paired - v = a - b for second slots
+
+      // Blend: for indices where bit log2(h) is 0, take sum; else take diff.
+      __mmask16 mask;
+      if (h == 1) {
+        mask = 0xAAAA;  // bits: 1010 1010 1010 1010  (odd positions)
+      } else if (h == 2) {
+        mask = 0xCCCC;  // bits: 1100 1100 1100 1100
+      } else if (h == 4) {
+        mask = 0xF0F0;  // bits: 1111 0000 1111 0000
+      } else {  // h == 8
+        mask = 0xFF00;  // bits: 1111 1111 0000 0000
+      }
+      __m512 result = _mm512_mask_blend_ps(mask, sum, diff);
+      _mm512_storeu_ps(row + j, result);
+    }
+  }
+
+  // Phase 2: h >= 16 — standard load-add/sub-store
+  for (int64_t h = 16; h < n; h <<= 1) {
+    for (int64_t j = 0; j < n; j += 2 * h) {
+      for (int64_t k = 0; k < h; k += 16) {
+        __m512 a = _mm512_loadu_ps(row + j + k);
+        __m512 b = _mm512_loadu_ps(row + j + k + h);
+        _mm512_storeu_ps(row + j + k,     _mm512_add_ps(a, b));
+        _mm512_storeu_ps(row + j + k + h, _mm512_sub_ps(a, b));
+      }
+    }
+  }
+
+  // Apply scale
+  __m512 scale_vec = _mm512_set1_ps(scale);
+  int64_t d = 0;
+  for (; d <= n - 16; d += 16) {
+    __m512 v = _mm512_loadu_ps(row + d);
+    _mm512_storeu_ps(row + d, _mm512_mul_ps(v, scale_vec));
+  }
+  for (; d < n; ++d) {
+    row[d] *= scale;
+  }
+}
+
+#endif  // CPU_CAPABILITY_AVX512
+
+}  // anonymous namespace
+
+// ──────────────────────────────────────────────────────────────────────
+// fast_hadamard_transform_cpu
+//
+// Input:  x      – arbitrary-shape tensor whose last dim is a power of 2
+//         scale  – multiplicative scale applied after the transform
+// Output: tensor of same shape/dtype with FWHT applied along the last dim
+// ──────────────────────────────────────────────────────────────────────
+at::Tensor fast_hadamard_transform_cpu(const at::Tensor& x, double scale) {
+  const int64_t n = x.size(-1);
+  TORCH_CHECK(n > 0 && (n & (n - 1)) == 0,
+              "fast_hadamard_transform: last dim must be a power of 2, got ", n);
+
+  // Flatten to 2-D, work in float, then cast back.
+  const int64_t rows = x.numel() / n;
+  auto x_flat = x.reshape({rows, n}).to(at::kFloat).contiguous();
+  auto out = x_flat.clone();  // mutable working copy
+  float* out_ptr = out.data_ptr<float>();
+
+  at::parallel_for(0, rows, /*grain_size=*/1, [&](int64_t begin, int64_t end) {
+    for (int64_t r = begin; r < end; ++r) {
+      float* row = out_ptr + r * n;
+#if defined(CPU_CAPABILITY_AVX512)
+      if (n >= 16) {
+        fwht_row_avx512(row, n, static_cast<float>(scale));
+      } else {
+        fwht_row_scalar(row, n, static_cast<float>(scale));
+      }
+#else
+      fwht_row_scalar(row, n, static_cast<float>(scale));
+#endif
+    }
+  });
+
+  // Reshape back and cast to original dtype.
+  return out.view(x.sizes()).to(x.scalar_type());
+}

--- a/sgl-kernel/csrc/cpu/hadamard.cpp
+++ b/sgl-kernel/csrc/cpu/hadamard.cpp
@@ -3,158 +3,209 @@
 
 namespace {
 
-// ──────────────────────────────────────────────────────────────────────
-// Iterative Cooley-Tukey-style Fast Walsh-Hadamard Transform (FWHT)
-// along the last dimension.  n must be a power of two.
-//
-// For each row of length n the butterfly loop is:
-//   for h = 1, 2, 4, …, n/2
-//     for every pair (a[j], b[j]) separated by stride h
-//       (a[j], b[j]) ← (a[j]+b[j], a[j]−b[j])
-//
-// When h >= 16 (== 512-bit / sizeof(float)) we can do the butterfly
-// entirely with AVX-512 loads/stores.  The inner two cases (h < 16)
-// use in-register shuffles so we never spill to memory at small
-// strides.
-// ──────────────────────────────────────────────────────────────────────
+using fVec = at::vec::Vectorized<float>;
 
-// Scalar fallback for a single row of length n
-inline void fwht_row_scalar(float* __restrict__ row, int64_t n, float scale) {
-  for (int64_t h = 1; h < n; h <<= 1) {
-    for (int64_t j = 0; j < n; j += 2 * h) {
-      for (int64_t k = 0; k < h; ++k) {
-        float a = row[j + k];
-        float b = row[j + k + h];
-        row[j + k]     = a + b;
-        row[j + k + h] = a - b;
-      }
-    }
+// ── Unified scalar FWHT ──
+// For float: buf unused, work=out; casts are no-ops.
+// For bf16/f16: work=buf as scratch; casts do dtype conversion.
+template <typename scalar_t>
+inline void fwht_row_scalar(
+    scalar_t* __restrict__ out,
+    const scalar_t* __restrict__ in,
+    float* __restrict__ buf,
+    int64_t n,
+    float scale) {
+  if (n == 1) {
+    out[0] = static_cast<scalar_t>(static_cast<float>(in[0]) * scale);
+    return;
   }
-  for (int64_t d = 0; d < n; ++d) {
-    row[d] *= scale;
+  if (n == 2) {
+    float a = static_cast<float>(in[0]), b = static_cast<float>(in[1]);
+    out[0] = static_cast<scalar_t>((a + b) * scale);
+    out[1] = static_cast<scalar_t>((a - b) * scale);
+    return;
+  }
+  float* work;
+  if constexpr (std::is_same_v<scalar_t, float>) {
+    work = out;
+  } else {
+    work = buf;
+  }
+  // h=1: read from in → work
+  for (int64_t j = 0; j < n; j += 2) {
+    float a = static_cast<float>(in[j]), b = static_cast<float>(in[j + 1]);
+    work[j]     = a + b;
+    work[j + 1] = a - b;
+  }
+  // h=2..n/4: in-place on work
+  const int64_t last_h = n >> 1;
+  for (int64_t h = 2; h < last_h; h <<= 1)
+    for (int64_t j = 0; j < n; j += 2 * h)
+      for (int64_t k = 0; k < h; ++k) {
+        float a = work[j + k], b = work[j + k + h];
+        work[j + k]     = a + b;
+        work[j + k + h] = a - b;
+      }
+  // h=n/2: butterfly + scale → out
+  for (int64_t k = 0; k < last_h; ++k) {
+    float a = work[k], b = work[k + last_h];
+    out[k]          = static_cast<scalar_t>((a + b) * scale);
+    out[k + last_h] = static_cast<scalar_t>((a - b) * scale);
   }
 }
 
 #if defined(CPU_CAPABILITY_AVX512)
 
-// AVX-512 optimized FWHT for a single row of length n (power of 2, n >= 16)
-inline void fwht_row_avx512(float* __restrict__ row, int64_t n, float scale) {
-  // For small strides (h < 16), we process 16 floats at a time using
-  // in-register shuffles to do butterflies without extra loads/stores.
-  // For h >= 16, we do standard load-butterfly-store with AVX-512.
+// Phase-1: in-register butterflies h=1,2,4,8.
+// Requires permute/blend intrinsics with no Vectorized equivalent.
+static inline __m512 fwht_phase1_fused(__m512 v) {
+  __m512 p, s, d;
+  p = _mm512_permute_ps(v, 0b10'11'00'01);                          // h=1
+  s = _mm512_add_ps(v, p); d = _mm512_sub_ps(p, v);
+  v = _mm512_mask_blend_ps((__mmask16)0xAAAA, s, d);
+  p = _mm512_permute_ps(v, 0b01'00'11'10);                          // h=2
+  s = _mm512_add_ps(v, p); d = _mm512_sub_ps(p, v);
+  v = _mm512_mask_blend_ps((__mmask16)0xCCCC, s, d);
+  p = _mm512_permutexvar_ps(                                         // h=4
+      _mm512_set_epi32(11,10,9,8, 15,14,13,12, 3,2,1,0, 7,6,5,4), v);
+  s = _mm512_add_ps(v, p); d = _mm512_sub_ps(p, v);
+  v = _mm512_mask_blend_ps((__mmask16)0xF0F0, s, d);
+  p = _mm512_permutexvar_ps(                                         // h=8
+      _mm512_set_epi32(7,6,5,4, 3,2,1,0, 15,14,13,12, 11,10,9,8), v);
+  s = _mm512_add_ps(v, p); d = _mm512_sub_ps(p, v);
+  v = _mm512_mask_blend_ps((__mmask16)0xFF00, s, d);
+  return v;
+}
 
-  // Phase 1: h = 1, 2, 4, 8 — in-register butterflies
-  // Process the row in chunks of 16 floats.
-  // For h=1: butterfly pairs at stride 1 within each 16-float chunk.
-  // For h=2: butterfly pairs at stride 2 within each 16-float chunk.
-  // etc.
+// fVec wrapper for fwht_phase1_fused
+static inline fVec fwht_phase1(fVec v) {
+  return fVec(fwht_phase1_fused(__m512(v)));
+}
 
-  for (int64_t h = 1; h < 16 && h < n; h <<= 1) {
-    for (int64_t j = 0; j < n; j += 16) {
-      __m512 v = _mm512_loadu_ps(row + j);
+// ── Vectorized dtype conversion (16 elements) ──
+// For float: identity load/store. For bf16/f16: intrinsic conversion.
+template <typename scalar_t> static inline fVec load_cvt(const scalar_t*);
+template <typename scalar_t> static inline void store_cvt(scalar_t*, fVec);
 
-      // Shuffle to get the paired element.
-      // For stride h, element i is paired with element i^h.
-      // We need to swap elements that differ in bit position log2(h).
-      __m512 paired;
-      if (h == 1) {
-        // swap adjacent: 0↔1, 2↔3, 4↔5, …
-        paired = _mm512_permute_ps(v, 0b10'11'00'01);
-      } else if (h == 2) {
-        // swap pairs: (0,1)↔(2,3), (4,5)↔(6,7), …
-        paired = _mm512_permute_ps(v, 0b01'00'11'10);
-      } else if (h == 4) {
-        // swap quads: (0..3)↔(4..7) within each 256-bit half
-        paired = _mm512_permutexvar_ps(
-            _mm512_set_epi32(11, 10, 9, 8, 15, 14, 13, 12, 3, 2, 1, 0, 7, 6, 5, 4), v);
-      } else {  // h == 8
-        // swap octets: (0..7)↔(8..15)
-        paired = _mm512_permutexvar_ps(
-            _mm512_set_epi32(7, 6, 5, 4, 3, 2, 1, 0, 15, 14, 13, 12, 11, 10, 9, 8), v);
+template <> inline fVec load_cvt<float>(const float* p) {
+  return fVec::loadu(p);
+}
+template <> inline fVec load_cvt<at::BFloat16>(const at::BFloat16* p) {
+  return fVec(CVT_BF16_TO_FP32(
+      _mm256_loadu_si256(reinterpret_cast<const __m256i*>(p))));
+}
+template <> inline fVec load_cvt<at::Half>(const at::Half* p) {
+  return fVec(CVT_FP16_TO_FP32(
+      _mm256_loadu_si256(reinterpret_cast<const __m256i*>(p))));
+}
+template <> inline void store_cvt<float>(float* p, fVec v) {
+  v.store(p);
+}
+template <> inline void store_cvt<at::BFloat16>(at::BFloat16* p, fVec v) {
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(p),
+      (__m256i)_mm512_cvtneps_pbh(__m512(v)));
+}
+template <> inline void store_cvt<at::Half>(at::Half* p, fVec v) {
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(p),
+      _mm512_cvtps_ph(__m512(v), _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC));
+}
+
+// Phase-2: h=16..last_h-1 vectorized butterflies on float buffer.
+static inline void fwht_phase2(float* __restrict__ buf, int64_t n, int64_t last_h) {
+  for (int64_t h = 16; h < last_h; h <<= 1)
+    for (int64_t j = 0; j < n; j += 2 * h)
+      for (int64_t k = 0; k < h; k += fVec::size()) {
+        fVec a = fVec::loadu(buf + j + k);
+        fVec b = fVec::loadu(buf + j + k + h);
+        (a + b).store(buf + j + k);
+        (a - b).store(buf + j + k + h);
       }
+}
 
-      // For the "first" slot (bit log2(h) == 0): v[i]=a, paired[i]=b → sum = a+b
-      // For the "second" slot (bit log2(h) == 1): v[i]=b, paired[i]=a → diff = a-b
-      __m512 sum  = _mm512_add_ps(v, paired);
-      __m512 diff = _mm512_sub_ps(paired, v);  // paired - v = a - b for second slots
-
-      // Blend: for indices where bit log2(h) is 0, take sum; else take diff.
-      __mmask16 mask;
-      if (h == 1) {
-        mask = 0xAAAA;  // bits: 1010 1010 1010 1010  (odd positions)
-      } else if (h == 2) {
-        mask = 0xCCCC;  // bits: 1100 1100 1100 1100
-      } else if (h == 4) {
-        mask = 0xF0F0;  // bits: 1111 0000 1111 0000
-      } else {  // h == 8
-        mask = 0xFF00;  // bits: 1111 1111 0000 0000
-      }
-      __m512 result = _mm512_mask_blend_ps(mask, sum, diff);
-      _mm512_storeu_ps(row + j, result);
-    }
+// Unified AVX-512 FWHT with optional dtype conversion.
+// For float: load_cvt/store_cvt are identity, work=out.
+// For bf16/f16: load_cvt/store_cvt handle conversion, work=buf.
+template <typename scalar_t>
+inline void fwht_row_avx512(
+    scalar_t* __restrict__ out,
+    const scalar_t* __restrict__ in,
+    float* __restrict__ buf,
+    int64_t n,
+    float scale) {
+  fVec sv(scale);
+  if (n == 16) {
+    store_cvt(out, fwht_phase1(load_cvt(in)) * sv);
+    return;
   }
 
-  // Phase 2: h >= 16 — standard load-add/sub-store
-  for (int64_t h = 16; h < n; h <<= 1) {
-    for (int64_t j = 0; j < n; j += 2 * h) {
-      for (int64_t k = 0; k < h; k += 16) {
-        __m512 a = _mm512_loadu_ps(row + j + k);
-        __m512 b = _mm512_loadu_ps(row + j + k + h);
-        _mm512_storeu_ps(row + j + k,     _mm512_add_ps(a, b));
-        _mm512_storeu_ps(row + j + k + h, _mm512_sub_ps(a, b));
-      }
-    }
+  float* work;
+  if constexpr (std::is_same_v<scalar_t, float>) {
+    work = out;
+  } else {
+    work = buf;
   }
 
-  // Apply scale
-  __m512 scale_vec = _mm512_set1_ps(scale);
-  int64_t d = 0;
-  for (; d <= n - 16; d += 16) {
-    __m512 v = _mm512_loadu_ps(row + d);
-    _mm512_storeu_ps(row + d, _mm512_mul_ps(v, scale_vec));
-  }
-  for (; d < n; ++d) {
-    row[d] *= scale;
+  // Phase 1: load (+ convert) → fused butterflies → work
+  for (int64_t j = 0; j < n; j += fVec::size())
+    fwht_phase1(load_cvt(in + j)).store(work + j);
+
+  // Phase 2: h=16..n/4 butterflies on work
+  const int64_t last_h = n >> 1;
+  fwht_phase2(work, n, last_h);
+
+  // Last stage: butterfly + scale (+ convert) → out
+  for (int64_t k = 0; k < last_h; k += fVec::size()) {
+    fVec a = fVec::loadu(work + k);
+    fVec b = fVec::loadu(work + k + last_h);
+    store_cvt(out + k,          (a + b) * sv);
+    store_cvt(out + k + last_h, (a - b) * sv);
   }
 }
 
 #endif  // CPU_CAPABILITY_AVX512
 
+template <typename scalar_t>
+void fast_hadamard_transform_kernel_impl(
+    scalar_t* __restrict__ output,
+    const scalar_t* __restrict__ input,
+    int64_t rows,
+    int64_t n,
+    float scale) {
+  at::parallel_for(0, rows, 1, [&](int64_t begin, int64_t end) {
+    float* buf = nullptr;
+    std::vector<float> scratch;
+    if constexpr (!std::is_same_v<scalar_t, float>) {
+      scratch.resize(n);
+      buf = scratch.data();
+    }
+    for (int64_t r = begin; r < end; ++r) {
+#if defined(CPU_CAPABILITY_AVX512)
+      if (n >= 16)
+        fwht_row_avx512(output + r * n, input + r * n, buf, n, scale);
+      else
+#endif
+        fwht_row_scalar(output + r * n, input + r * n, buf, n, scale);
+    }
+  });
+}
+
 }  // anonymous namespace
 
-// ──────────────────────────────────────────────────────────────────────
-// fast_hadamard_transform_cpu
-//
-// Input:  x      – arbitrary-shape tensor whose last dim is a power of 2
-//         scale  – multiplicative scale applied after the transform
-// Output: tensor of same shape/dtype with FWHT applied along the last dim
-// ──────────────────────────────────────────────────────────────────────
 at::Tensor fast_hadamard_transform_cpu(const at::Tensor& x, double scale) {
+  CHECK_INPUT(x);
   const int64_t n = x.size(-1);
   TORCH_CHECK(n > 0 && (n & (n - 1)) == 0,
               "fast_hadamard_transform: last dim must be a power of 2, got ", n);
 
-  // Flatten to 2-D, work in float, then cast back.
   const int64_t rows = x.numel() / n;
-  auto x_flat = x.reshape({rows, n}).to(at::kFloat).contiguous();
-  auto out = x_flat.clone();  // mutable working copy
-  float* out_ptr = out.data_ptr<float>();
+  auto out = at::empty_like(x);
+  const float s = static_cast<float>(scale);
 
-  at::parallel_for(0, rows, /*grain_size=*/1, [&](int64_t begin, int64_t end) {
-    for (int64_t r = begin; r < end; ++r) {
-      float* row = out_ptr + r * n;
-#if defined(CPU_CAPABILITY_AVX512)
-      if (n >= 16) {
-        fwht_row_avx512(row, n, static_cast<float>(scale));
-      } else {
-        fwht_row_scalar(row, n, static_cast<float>(scale));
-      }
-#else
-      fwht_row_scalar(row, n, static_cast<float>(scale));
-#endif
-    }
+  CPU_DISPATCH_FLOATING_TYPES(x.scalar_type(),
+      "fast_hadamard_transform_cpu", [&] {
+    fast_hadamard_transform_kernel_impl<scalar_t>(
+        out.data_ptr<scalar_t>(), x.data_ptr<scalar_t>(), rows, n, s);
   });
 
-  // Reshape back and cast to original dtype.
-  return out.view(x.sizes()).to(x.scalar_type());
+  return out;
 }

--- a/sgl-kernel/csrc/cpu/store_cache.cpp
+++ b/sgl-kernel/csrc/cpu/store_cache.cpp
@@ -1,6 +1,139 @@
 #include "common.h"
+#include <cmath>
 #include <cstring>
 #include <immintrin.h>
+
+
+// ============================================================================
+// quant_to_nope_fp8_rope_bf16_pack_cpu
+//
+// Equivalent to Python:
+//   k_nope_bf16, k_rope_bf16 = k_bf16.split([448, 64], dim=-1)
+//   x = k_nope_bf16.view(-1, 7, 64)
+//   scale = x.abs().amax(dim=-1).float() / 448.0
+//   scale_pow2 = 2^ceil(log2(max(scale, 1e-4)))
+//   k_nope_fp8 = (x.float() / scale_pow2.unsqueeze(-1)).to(fp8_e4m3fn)
+//   scale_uint8 = e8m0_encode(scale_pow2) -> (ceil_log2 + 127)
+// ============================================================================
+
+namespace {
+
+constexpr int64_t QUANT_DIM_NOPE = 448;
+constexpr int64_t QUANT_DIM_ROPE = 64;
+constexpr int64_t QUANT_TILE_SIZE = 64;
+constexpr int64_t QUANT_NUM_TILES = QUANT_DIM_NOPE / QUANT_TILE_SIZE;  // 7
+constexpr float QUANT_FP8_MAX = 448.0f;
+constexpr float QUANT_FP8_MIN = -448.0f;
+constexpr float QUANT_EPS = 1e-4f;
+
+// Float to fp8_e4m3fn using PyTorch's conversion for correctness
+inline uint8_t float_to_fp8_e4m3fn(float val) {
+  return at::Float8_e4m3fn(val).x;
+}
+
+#if defined(CPU_CAPABILITY_AVX512)
+
+// Process one tile (64 bf16 values): find amax, compute scale, quantize to fp8
+inline uint8_t quantize_tile_avx512(
+    const at::BFloat16* __restrict__ src,
+    uint8_t* __restrict__ dst) {
+
+  // Load 64 bf16 -> 4 x 16 floats
+  __m256i bf16_0 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src));
+  __m256i bf16_1 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + 16));
+  __m256i bf16_2 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + 32));
+  __m256i bf16_3 = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src + 48));
+
+  __m512 f0 = _mm512_castsi512_ps(_mm512_slli_epi32(_mm512_cvtepu16_epi32(bf16_0), 16));
+  __m512 f1 = _mm512_castsi512_ps(_mm512_slli_epi32(_mm512_cvtepu16_epi32(bf16_1), 16));
+  __m512 f2 = _mm512_castsi512_ps(_mm512_slli_epi32(_mm512_cvtepu16_epi32(bf16_2), 16));
+  __m512 f3 = _mm512_castsi512_ps(_mm512_slli_epi32(_mm512_cvtepu16_epi32(bf16_3), 16));
+
+  // Absolute values
+  const __m512i abs_mask_i = _mm512_set1_epi32(0x7FFFFFFF);
+  __m512 abs0 = _mm512_castsi512_ps(_mm512_and_si512(_mm512_castps_si512(f0), abs_mask_i));
+  __m512 abs1 = _mm512_castsi512_ps(_mm512_and_si512(_mm512_castps_si512(f1), abs_mask_i));
+  __m512 abs2 = _mm512_castsi512_ps(_mm512_and_si512(_mm512_castps_si512(f2), abs_mask_i));
+  __m512 abs3 = _mm512_castsi512_ps(_mm512_and_si512(_mm512_castps_si512(f3), abs_mask_i));
+
+  // Horizontal max
+  __m512 max01 = _mm512_max_ps(abs0, abs1);
+  __m512 max23 = _mm512_max_ps(abs2, abs3);
+  __m512 max0123 = _mm512_max_ps(max01, max23);
+  float amax = _mm512_reduce_max_ps(max0123);
+
+  // Scale computation
+  float scale = std::max(amax / QUANT_FP8_MAX, QUANT_EPS);
+  float ceil_log2 = std::ceil(std::log2(scale));
+  float scale_pow2 = std::exp2(ceil_log2);
+  float scale_inv = 1.0f / scale_pow2;
+
+  int exponent = static_cast<int>(ceil_log2);
+  uint8_t scale_uint8 = static_cast<uint8_t>(exponent + 127);
+
+  // Scale all values
+  __m512 vinv = _mm512_set1_ps(scale_inv);
+  __m512 s0 = _mm512_mul_ps(f0, vinv);
+  __m512 s1 = _mm512_mul_ps(f1, vinv);
+  __m512 s2 = _mm512_mul_ps(f2, vinv);
+  __m512 s3 = _mm512_mul_ps(f3, vinv);
+
+  // Clamp
+  __m512 vmax = _mm512_set1_ps(QUANT_FP8_MAX);
+  __m512 vmin = _mm512_set1_ps(QUANT_FP8_MIN);
+  s0 = _mm512_max_ps(_mm512_min_ps(s0, vmax), vmin);
+  s1 = _mm512_max_ps(_mm512_min_ps(s1, vmax), vmin);
+  s2 = _mm512_max_ps(_mm512_min_ps(s2, vmax), vmin);
+  s3 = _mm512_max_ps(_mm512_min_ps(s3, vmax), vmin);
+
+  // Convert float -> fp8
+  alignas(64) float buf[16];
+
+  _mm512_store_ps(buf, s0);
+  for (int j = 0; j < 16; ++j) dst[j] = float_to_fp8_e4m3fn(buf[j]);
+
+  _mm512_store_ps(buf, s1);
+  for (int j = 0; j < 16; ++j) dst[16 + j] = float_to_fp8_e4m3fn(buf[j]);
+
+  _mm512_store_ps(buf, s2);
+  for (int j = 0; j < 16; ++j) dst[32 + j] = float_to_fp8_e4m3fn(buf[j]);
+
+  _mm512_store_ps(buf, s3);
+  for (int j = 0; j < 16; ++j) dst[48 + j] = float_to_fp8_e4m3fn(buf[j]);
+
+  return scale_uint8;
+}
+
+#endif  // CPU_CAPABILITY_AVX512
+
+inline uint8_t quantize_tile_scalar(
+    const at::BFloat16* __restrict__ src,
+    uint8_t* __restrict__ dst) {
+
+  float amax = 0.0f;
+  for (int j = 0; j < QUANT_TILE_SIZE; ++j) {
+    float v = std::abs(static_cast<float>(src[j]));
+    if (v > amax) amax = v;
+  }
+
+  float scale = std::max(amax / QUANT_FP8_MAX, QUANT_EPS);
+  float ceil_log2 = std::ceil(std::log2(scale));
+  float scale_pow2 = std::exp2(ceil_log2);
+  float scale_inv = 1.0f / scale_pow2;
+
+  int exponent = static_cast<int>(ceil_log2);
+  uint8_t scale_uint8 = static_cast<uint8_t>(exponent + 127);
+
+  for (int j = 0; j < QUANT_TILE_SIZE; ++j) {
+    float val = static_cast<float>(src[j]) * scale_inv;
+    val = std::max(std::min(val, QUANT_FP8_MAX), QUANT_FP8_MIN);
+    dst[j] = float_to_fp8_e4m3fn(val);
+  }
+
+  return scale_uint8;
+}
+
+}  // anonymous namespace
 
 // set_k_and_s_cpu: scatter-copy k_nope (fp8), k_rope (bf16), and
 // scale_k_nope (uint8) into a paged KV-cache buffer.
@@ -99,4 +232,54 @@ void set_k_and_s_cpu(
       std::memcpy(dst_scale, src_scale, scale_dim);
     }
   });
+}
+
+
+std::tuple<at::Tensor, at::Tensor, at::Tensor>
+quant_to_nope_fp8_rope_bf16_pack_cpu(at::Tensor& k_bf16) {
+  TORCH_CHECK(k_bf16.dtype() == at::kBFloat16,
+      "quant_to_nope_fp8_rope_bf16_pack_cpu: expect bf16 input, got ", k_bf16.dtype());
+  TORCH_CHECK(k_bf16.dim() == 2 && k_bf16.size(1) == 512,
+      "quant_to_nope_fp8_rope_bf16_pack_cpu: expect input shape [N, 512]");
+  TORCH_CHECK(k_bf16.is_contiguous(),
+      "quant_to_nope_fp8_rope_bf16_pack_cpu: expect contiguous input");
+
+  const int64_t num_tokens = k_bf16.size(0);
+
+  auto k_nope_fp8 = at::empty({num_tokens, QUANT_DIM_NOPE},
+      k_bf16.options().dtype(at::kFloat8_e4m3fn));
+  auto k_rope_bf16 = at::empty({num_tokens, QUANT_DIM_ROPE},
+      k_bf16.options().dtype(at::kBFloat16));
+  auto scale_out = at::empty({num_tokens, QUANT_NUM_TILES},
+      k_bf16.options().dtype(at::kByte));
+
+  const at::BFloat16* input_ptr = k_bf16.data_ptr<at::BFloat16>();
+  uint8_t* nope_ptr = reinterpret_cast<uint8_t*>(k_nope_fp8.data_ptr());
+  at::BFloat16* rope_ptr = k_rope_bf16.data_ptr<at::BFloat16>();
+  uint8_t* scale_ptr = scale_out.data_ptr<uint8_t>();
+
+  at::parallel_for(0, num_tokens, /*grain_size=*/64, [&](int64_t begin, int64_t end) {
+    for (int64_t t = begin; t < end; ++t) {
+      const at::BFloat16* src_token = input_ptr + t * 512;
+
+      // Copy rope portion (last 64 bf16 values = 128 bytes)
+      std::memcpy(rope_ptr + t * QUANT_DIM_ROPE,
+                  src_token + QUANT_DIM_NOPE,
+                  QUANT_DIM_ROPE * sizeof(at::BFloat16));
+
+      // Quantize each nope tile
+      for (int64_t tile = 0; tile < QUANT_NUM_TILES; ++tile) {
+        const at::BFloat16* tile_src = src_token + tile * QUANT_TILE_SIZE;
+        uint8_t* tile_dst = nope_ptr + t * QUANT_DIM_NOPE + tile * QUANT_TILE_SIZE;
+
+#if defined(CPU_CAPABILITY_AVX512)
+        scale_ptr[t * QUANT_NUM_TILES + tile] = quantize_tile_avx512(tile_src, tile_dst);
+#else
+        scale_ptr[t * QUANT_NUM_TILES + tile] = quantize_tile_scalar(tile_src, tile_dst);
+#endif
+      }
+    }
+  });
+
+  return std::make_tuple(k_nope_fp8, k_rope_bf16, scale_out);
 }

--- a/sgl-kernel/csrc/cpu/store_cache.cpp
+++ b/sgl-kernel/csrc/cpu/store_cache.cpp
@@ -26,12 +26,73 @@ constexpr float QUANT_FP8_MAX = 448.0f;
 constexpr float QUANT_FP8_MIN = -448.0f;
 constexpr float QUANT_EPS = 1e-4f;
 
-// Float to fp8_e4m3fn using PyTorch's conversion for correctness
+// Float to fp8_e4m3fn using PyTorch's conversion (scalar fallback)
 inline uint8_t float_to_fp8_e4m3fn(float val) {
   return at::Float8_e4m3fn(val).x;
 }
 
 #if defined(CPU_CAPABILITY_AVX512)
+
+// Vectorized float32x16 -> fp8_e4m3fn x16 using AVX512 bit manipulation.
+// Implements RNE (round-to-nearest-even). Flushes subnormal fp8 to zero
+// (safe because SGLANG_CPU_FP8_CVT_FTZ flushes them on decode too).
+// fp8_e4m3fn: sign(1), exp(4, bias=7), mant(3), no inf/nan special values.
+// Normal: exp_field in [1..15], value = 2^(exp-7) * (1 + mant/8)
+// Input assumed clamped to [-448, 448].
+inline __m128i cvt_fp32x16_to_fp8x16(__m512 input) {
+  __m512i bits = _mm512_castps_si512(input);
+
+  // Extract sign -> bit 7 of fp8 byte
+  __m512i signs = _mm512_srli_epi32(_mm512_and_si512(bits, _mm512_set1_epi32(0x80000000)), 24);
+
+  // Absolute value bits
+  __m512i abs_bits = _mm512_and_si512(bits, _mm512_set1_epi32(0x7FFFFFFF));
+
+  // Float32 biased exponent
+  __m512i f32_exp = _mm512_srli_epi32(abs_bits, 23);
+
+  // Float32 mantissa (23 bits)
+  __m512i f32_mant = _mm512_and_si512(abs_bits, _mm512_set1_epi32(0x7FFFFF));
+
+  // fp8_exp = f32_exp - 120 (rebias from 127 to 7)
+  __m512i fp8_exp = _mm512_sub_epi32(f32_exp, _mm512_set1_epi32(120));
+
+  // Top 3 mantissa bits
+  __m512i mant3 = _mm512_srli_epi32(f32_mant, 20);
+
+  // RNE rounding: round_bit = bit 19, sticky = bits[18:0]
+  __m512i round_bit = _mm512_and_si512(_mm512_srli_epi32(f32_mant, 19), _mm512_set1_epi32(1));
+  __m512i sticky_bits = _mm512_and_si512(f32_mant, _mm512_set1_epi32(0x7FFFF));
+  __mmask16 has_sticky = _mm512_cmpneq_epi32_mask(sticky_bits, _mm512_setzero_si512());
+
+  // Round up if round_bit AND (sticky OR lsb_of_mant3)
+  __m512i lsb = _mm512_and_si512(mant3, _mm512_set1_epi32(1));
+  __m512i sticky_or_lsb = _mm512_or_si512(
+      _mm512_maskz_mov_epi32(has_sticky, _mm512_set1_epi32(1)), lsb);
+  __m512i do_round = _mm512_and_si512(round_bit, sticky_or_lsb);
+  mant3 = _mm512_add_epi32(mant3, do_round);
+
+  // Mantissa overflow (mant3 == 8) -> increment exponent, zero mantissa
+  __mmask16 mant_ovf = _mm512_cmpeq_epi32_mask(mant3, _mm512_set1_epi32(8));
+  mant3 = _mm512_mask_mov_epi32(mant3, mant_ovf, _mm512_setzero_si512());
+  fp8_exp = _mm512_mask_add_epi32(fp8_exp, mant_ovf, fp8_exp, _mm512_set1_epi32(1));
+
+  // Clamp exponent: max 15
+  fp8_exp = _mm512_min_epi32(fp8_exp, _mm512_set1_epi32(15));
+
+  // Result: (fp8_exp << 3) | mant3
+  __m512i result = _mm512_or_si512(_mm512_slli_epi32(fp8_exp, 3), mant3);
+
+  // Flush to zero: if f32_exp < 121 (would be subnormal in fp8), output 0
+  __mmask16 is_subnormal_or_zero = _mm512_cmplt_epi32_mask(f32_exp, _mm512_set1_epi32(121));
+  result = _mm512_mask_mov_epi32(result, is_subnormal_or_zero, _mm512_setzero_si512());
+
+  // Add sign
+  result = _mm512_or_si512(result, signs);
+
+  // Pack 16 x i32 -> 16 x i8
+  return _mm512_cvtepi32_epi8(result);
+}
 
 // Process one tile (64 bf16 values): find amax, compute scale, quantize to fp8
 inline uint8_t quantize_tile_avx512(
@@ -86,20 +147,16 @@ inline uint8_t quantize_tile_avx512(
   s2 = _mm512_max_ps(_mm512_min_ps(s2, vmax), vmin);
   s3 = _mm512_max_ps(_mm512_min_ps(s3, vmax), vmin);
 
-  // Convert float -> fp8
-  alignas(64) float buf[16];
+  // Vectorized float -> fp8 conversion (16 values at a time)
+  __m128i fp8_0 = cvt_fp32x16_to_fp8x16(s0);
+  __m128i fp8_1 = cvt_fp32x16_to_fp8x16(s1);
+  __m128i fp8_2 = cvt_fp32x16_to_fp8x16(s2);
+  __m128i fp8_3 = cvt_fp32x16_to_fp8x16(s3);
 
-  _mm512_store_ps(buf, s0);
-  for (int j = 0; j < 16; ++j) dst[j] = float_to_fp8_e4m3fn(buf[j]);
-
-  _mm512_store_ps(buf, s1);
-  for (int j = 0; j < 16; ++j) dst[16 + j] = float_to_fp8_e4m3fn(buf[j]);
-
-  _mm512_store_ps(buf, s2);
-  for (int j = 0; j < 16; ++j) dst[32 + j] = float_to_fp8_e4m3fn(buf[j]);
-
-  _mm512_store_ps(buf, s3);
-  for (int j = 0; j < 16; ++j) dst[48 + j] = float_to_fp8_e4m3fn(buf[j]);
+  _mm_storeu_si128(reinterpret_cast<__m128i*>(dst), fp8_0);
+  _mm_storeu_si128(reinterpret_cast<__m128i*>(dst + 16), fp8_1);
+  _mm_storeu_si128(reinterpret_cast<__m128i*>(dst + 32), fp8_2);
+  _mm_storeu_si128(reinterpret_cast<__m128i*>(dst + 48), fp8_3);
 
   return scale_uint8;
 }
@@ -171,7 +228,7 @@ void set_k_and_s_cpu(
   const int32_t* loc_i32 = loc_is_int64 ? nullptr : loc.data_ptr<int32_t>();
   const int64_t* loc_i64 = loc_is_int64 ? loc.data_ptr<int64_t>() : nullptr;
 
-  at::parallel_for(0, num_tokens, 1, [&](int64_t begin, int64_t end) {
+  at::parallel_for(0, num_tokens, 0, [&](int64_t begin, int64_t end) {
     for (int64_t i = begin; i < end; ++i) {
       const int64_t token_loc = loc_is_int64 ? loc_i64[i] : static_cast<int64_t>(loc_i32[i]);
       const int64_t page_idx = token_loc / page_size;
@@ -258,7 +315,7 @@ quant_to_nope_fp8_rope_bf16_pack_cpu(at::Tensor& k_bf16) {
   at::BFloat16* rope_ptr = k_rope_bf16.data_ptr<at::BFloat16>();
   uint8_t* scale_ptr = scale_out.data_ptr<uint8_t>();
 
-  at::parallel_for(0, num_tokens, /*grain_size=*/64, [&](int64_t begin, int64_t end) {
+  at::parallel_for(0, num_tokens, 0, [&](int64_t begin, int64_t end) {
     for (int64_t t = begin; t < end; ++t) {
       const at::BFloat16* src_token = input_ptr + t * 512;
 

--- a/sgl-kernel/csrc/cpu/store_cache.cpp
+++ b/sgl-kernel/csrc/cpu/store_cache.cpp
@@ -1,0 +1,102 @@
+#include "common.h"
+#include <cstring>
+#include <immintrin.h>
+
+// set_k_and_s_cpu: scatter-copy k_nope (fp8), k_rope (bf16), and
+// scale_k_nope (uint8) into a paged KV-cache buffer.
+//
+// Buffer layout per page (buf shape: [num_pages, buf_numel_per_page]):
+//   Token data region: page_size * (nope_dim + rope_dim*2) bytes
+//     Per token: [nope_dim bytes fp8 | rope_dim*2 bytes bf16]
+//   Scale region: page_size * (scale_dim + 1) bytes
+//     Per token: [scale_dim bytes | 1 byte padding]
+//
+void set_k_and_s_cpu(
+    at::Tensor& buf,         // [num_pages, buf_numel_per_page], uint8
+    at::Tensor& loc,         // [num_tokens], int32 or int64
+    at::Tensor& k_nope,      // [num_tokens, nope_dim], fp8 (viewed as uint8)
+    at::Tensor& k_rope,      // [num_tokens, rope_dim], bf16 (viewed as uint8, rope_dim*2 bytes)
+    at::Tensor& scale_k_nope,// [num_tokens, scale_dim], uint8
+    int64_t page_size) {
+  const int64_t num_tokens = loc.size(0);
+  const int64_t buf_numel_per_page = buf.size(1);
+  const int64_t nope_dim = k_nope.size(1);       // 448 (bytes, fp8 elements)
+  const int64_t rope_dim = k_rope.size(1);        // 64 (bf16 elements, 128 bytes)
+  const int64_t scale_dim = scale_k_nope.size(1); // 7
+
+  const int64_t nope_rope_bytes = nope_dim + rope_dim * 2;
+  const int64_t s_offset_nbytes_in_page = page_size * nope_rope_bytes;
+  const int64_t padded_scale_per_token = scale_dim + 1;
+
+  uint8_t* buf_ptr = buf.data_ptr<uint8_t>();
+  const uint8_t* k_nope_ptr = reinterpret_cast<const uint8_t*>(k_nope.data_ptr());
+  const uint8_t* k_rope_ptr = reinterpret_cast<const uint8_t*>(k_rope.data_ptr());
+  const uint8_t* scale_ptr = scale_k_nope.data_ptr<uint8_t>();
+
+  // We handle both int32 and int64 loc
+  const bool loc_is_int64 = (loc.scalar_type() == at::kLong);
+  const int32_t* loc_i32 = loc_is_int64 ? nullptr : loc.data_ptr<int32_t>();
+  const int64_t* loc_i64 = loc_is_int64 ? loc.data_ptr<int64_t>() : nullptr;
+
+  at::parallel_for(0, num_tokens, 1, [&](int64_t begin, int64_t end) {
+    for (int64_t i = begin; i < end; ++i) {
+      const int64_t token_loc = loc_is_int64 ? loc_i64[i] : static_cast<int64_t>(loc_i32[i]);
+      const int64_t page_idx = token_loc / page_size;
+      const int64_t token_off = token_loc % page_size;
+
+      // --- nope: copy nope_dim bytes (fp8) ---
+      const int64_t nope_byte_offset =
+          page_idx * buf_numel_per_page + token_off * nope_rope_bytes;
+      uint8_t* dst_nope = buf_ptr + nope_byte_offset;
+      const uint8_t* src_nope = k_nope_ptr + i * nope_dim;
+
+#if defined(CPU_CAPABILITY_AVX512)
+      // nope_dim=448: 7 x 64-byte AVX512 stores
+      {
+        int64_t d = 0;
+        for (; d + 64 <= nope_dim; d += 64) {
+          __m512i v = _mm512_loadu_si512(reinterpret_cast<const __m512i*>(src_nope + d));
+          _mm512_storeu_si512(reinterpret_cast<__m512i*>(dst_nope + d), v);
+        }
+        // Handle remainder (nope_dim % 64 == 0 for 448, but be safe)
+        if (d < nope_dim) {
+          std::memcpy(dst_nope + d, src_nope + d, nope_dim - d);
+        }
+      }
+#else
+      std::memcpy(dst_nope, src_nope, nope_dim);
+#endif
+
+      // --- rope: copy rope_dim bf16 values = rope_dim*2 bytes ---
+      const int64_t rope_byte_offset =
+          page_idx * buf_numel_per_page + token_off * nope_rope_bytes + nope_dim;
+      uint8_t* dst_rope = buf_ptr + rope_byte_offset;
+      const uint8_t* src_rope = k_rope_ptr + i * rope_dim * 2;
+      const int64_t rope_bytes = rope_dim * 2;
+
+#if defined(CPU_CAPABILITY_AVX512)
+      // rope_bytes=128: 2 x 64-byte AVX512 stores
+      {
+        int64_t d = 0;
+        for (; d + 64 <= rope_bytes; d += 64) {
+          __m512i v = _mm512_loadu_si512(reinterpret_cast<const __m512i*>(src_rope + d));
+          _mm512_storeu_si512(reinterpret_cast<__m512i*>(dst_rope + d), v);
+        }
+        if (d < rope_bytes) {
+          std::memcpy(dst_rope + d, src_rope + d, rope_bytes - d);
+        }
+      }
+#else
+      std::memcpy(dst_rope, src_rope, rope_bytes);
+#endif
+
+      // --- scale: copy scale_dim bytes ---
+      const int64_t s_byte_offset =
+          page_idx * buf_numel_per_page + s_offset_nbytes_in_page
+          + token_off * padded_scale_per_token;
+      uint8_t* dst_scale = buf_ptr + s_byte_offset;
+      const uint8_t* src_scale = scale_ptr + i * scale_dim;
+      std::memcpy(dst_scale, src_scale, scale_dim);
+    }
+  });
+}

--- a/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
+++ b/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
@@ -51,6 +51,10 @@ void fused_add_layernorm_cpu(at::Tensor& input, at::Tensor& residual, at::Tensor
 // topk
 std::tuple<at::Tensor, at::Tensor>
 topk_sigmoid_cpu(at::Tensor& hidden_states, at::Tensor& gating_output, int64_t topk, bool renormalize);
+
+// hadamard transform
+at::Tensor fast_hadamard_transform_cpu(const at::Tensor& x, double scale);
+
 std::tuple<at::Tensor, at::Tensor>
 topk_softmax_cpu(at::Tensor& hidden_states, at::Tensor& gating_output, int64_t topk, bool renormalize);
 
@@ -589,6 +593,10 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
 
   // CPU and memory binding
   m.def("init_cpu_threads_env(str cpu_ids) -> str");
+
+  // hadamard transform
+  m.def("fast_hadamard_transform_cpu(Tensor x, float scale) -> Tensor");
+  m.impl("fast_hadamard_transform_cpu", torch::kCPU, &fast_hadamard_transform_cpu);
 
   // fused_sigmoid_gating_delta_rule_update
   m.def(

--- a/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
+++ b/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
@@ -356,6 +356,15 @@ std::tuple<at::Tensor, at::Tensor> rotary_embedding_cpu(
 // CPU and memory binding
 std::string init_cpu_threads_env(const std::string& cpu_ids);
 
+// set_k_and_s
+void set_k_and_s_cpu(
+    at::Tensor& buf,
+    at::Tensor& loc,
+    at::Tensor& k_nope,
+    at::Tensor& k_rope,
+    at::Tensor& scale_k_nope,
+    int64_t page_size);
+
 // fused_sigmoid_gating_delta_rule_update
 at::Tensor fused_sigmoid_gating_delta_rule_update_cpu(
     const at::Tensor& A_log,
@@ -597,6 +606,12 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   // hadamard transform
   m.def("fast_hadamard_transform_cpu(Tensor x, float scale) -> Tensor");
   m.impl("fast_hadamard_transform_cpu", torch::kCPU, &fast_hadamard_transform_cpu);
+
+  // set_k_and_s
+  m.def(
+      "set_k_and_s_cpu(Tensor(a!) buf, Tensor loc, Tensor k_nope, Tensor k_rope, "
+      "Tensor scale_k_nope, int page_size) -> ()");
+  m.impl("set_k_and_s_cpu", torch::kCPU, &set_k_and_s_cpu);
 
   // fused_sigmoid_gating_delta_rule_update
   m.def(

--- a/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
+++ b/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
@@ -365,6 +365,10 @@ void set_k_and_s_cpu(
     at::Tensor& scale_k_nope,
     int64_t page_size);
 
+// quant_to_nope_fp8_rope_bf16_pack
+std::tuple<at::Tensor, at::Tensor, at::Tensor>
+quant_to_nope_fp8_rope_bf16_pack_cpu(at::Tensor& k_bf16);
+
 // fused_sigmoid_gating_delta_rule_update
 at::Tensor fused_sigmoid_gating_delta_rule_update_cpu(
     const at::Tensor& A_log,
@@ -612,6 +616,11 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "set_k_and_s_cpu(Tensor(a!) buf, Tensor loc, Tensor k_nope, Tensor k_rope, "
       "Tensor scale_k_nope, int page_size) -> ()");
   m.impl("set_k_and_s_cpu", torch::kCPU, &set_k_and_s_cpu);
+
+  // quant_to_nope_fp8_rope_bf16_pack
+  m.def(
+      "quant_to_nope_fp8_rope_bf16_pack_cpu(Tensor k_bf16) -> (Tensor, Tensor, Tensor)");
+  m.impl("quant_to_nope_fp8_rope_bf16_pack_cpu", torch::kCPU, &quant_to_nope_fp8_rope_bf16_pack_cpu);
 
   // fused_sigmoid_gating_delta_rule_update
   m.def(

--- a/test/srt/cpu/test_hadamard.py
+++ b/test/srt/cpu/test_hadamard.py
@@ -1,0 +1,98 @@
+import itertools
+import unittest
+
+import torch
+from utils import precision
+
+from sglang.test.test_utils import CustomTestCase
+
+torch.manual_seed(42)
+
+
+def _torch_hadamard_transform(x: torch.Tensor, scale: float) -> torch.Tensor:
+    """Reference pure-torch FWHT implementation."""
+    n = x.size(-1)
+    leading = x.shape[:-1]
+    out = x.reshape(-1, n).float().clone()
+    h = 1
+    while h < n:
+        out = out.view(-1, n // (2 * h), 2, h)
+        a = out[:, :, 0, :]
+        b = out[:, :, 1, :]
+        out = torch.stack((a + b, a - b), dim=2).view(-1, n)
+        h *= 2
+    return (out.view(*leading, n) * scale).to(x.dtype)
+
+
+class TestHadamardTransform(CustomTestCase):
+    # Last dim must be power of 2
+    N = [2, 4, 8, 16, 32, 64, 128, 256, 512, 1024]
+    BATCH = [1, 3, 7, 16]
+    DTYPE = [torch.float32, torch.bfloat16, torch.float16]
+
+    def _test_hadamard(self, batch, n, dtype):
+        x = torch.randn([batch, n], dtype=dtype)
+        scale = n**-0.5
+
+        out = torch.ops.sgl_kernel.fast_hadamard_transform_cpu(x, scale)
+        ref = _torch_hadamard_transform(x, scale)
+
+        atol = rtol = precision[dtype]
+        torch.testing.assert_close(ref, out, atol=atol, rtol=rtol)
+
+    def test_basic(self):
+        """Test across various batch sizes, dimensions, and dtypes."""
+        for params in itertools.product(self.BATCH, self.N, self.DTYPE):
+            with self.subTest(batch=params[0], n=params[1], dtype=params[2]):
+                self._test_hadamard(*params)
+
+    def test_3d_input(self):
+        """Test with 3-D input tensor (e.g. [B, S, D])."""
+        for n in [32, 64, 128, 256]:
+            for dtype in [torch.bfloat16, torch.float32]:
+                x = torch.randn([2, 8, n], dtype=dtype)
+                scale = n**-0.5
+                out = torch.ops.sgl_kernel.fast_hadamard_transform_cpu(x, scale)
+                ref = _torch_hadamard_transform(x, scale)
+                atol = rtol = precision[dtype]
+                torch.testing.assert_close(ref, out, atol=atol, rtol=rtol)
+
+    def test_4d_input(self):
+        """Test with 4-D input tensor (e.g. [B, H, S, D])."""
+        for n in [32, 128]:
+            x = torch.randn([2, 4, 8, n], dtype=torch.bfloat16)
+            scale = n**-0.5
+            out = torch.ops.sgl_kernel.fast_hadamard_transform_cpu(x, scale)
+            ref = _torch_hadamard_transform(x, scale)
+            atol = rtol = precision[torch.bfloat16]
+            torch.testing.assert_close(ref, out, atol=atol, rtol=rtol)
+
+    def test_scale_one(self):
+        """Test with scale=1.0 (no scaling)."""
+        x = torch.randn([4, 64], dtype=torch.float32)
+        out = torch.ops.sgl_kernel.fast_hadamard_transform_cpu(x, 1.0)
+        ref = _torch_hadamard_transform(x, 1.0)
+        torch.testing.assert_close(ref, out, atol=1e-5, rtol=1e-5)
+
+    def test_large_dim(self):
+        """Test with large last dimension typical of LLM hidden sizes."""
+        for n in [2048, 4096]:
+            x = torch.randn([2, n], dtype=torch.bfloat16)
+            scale = n**-0.5
+            out = torch.ops.sgl_kernel.fast_hadamard_transform_cpu(x, scale)
+            ref = _torch_hadamard_transform(x, scale)
+            atol = rtol = precision[torch.bfloat16]
+            torch.testing.assert_close(ref, out, atol=atol, rtol=rtol)
+
+    def test_involution(self):
+        """FWHT applied twice (with scale=1/n) should recover the original."""
+        n = 128
+        x = torch.randn([4, n], dtype=torch.float32)
+        # H * H = n * I, so applying twice with scale 1/n gives identity.
+        y = torch.ops.sgl_kernel.fast_hadamard_transform_cpu(x, 1.0)
+        z = torch.ops.sgl_kernel.fast_hadamard_transform_cpu(y, 1.0 / n)
+        torch.testing.assert_close(x, z, atol=1e-4, rtol=1e-4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/cpu/test_store_cache.py
+++ b/test/srt/cpu/test_store_cache.py
@@ -1,0 +1,142 @@
+import itertools
+import unittest
+
+import torch
+
+from sglang.srt.layers.quantization.fp8_kernel import is_fp8_fnuz
+from sglang.test.test_utils import CustomTestCase
+
+torch.manual_seed(42)
+
+fp8_dtype = torch.float8_e4m3fnuz if is_fp8_fnuz() else torch.float8_e4m3fn
+
+# Reference implementation (from index_buf_accessor_v4.py)
+def _set_k_and_s_torch(buf, loc, k_nope, k_rope, scale_k_nope, page_size):
+    num_pages, buf_numel_per_page = buf.shape
+    (num_tokens_to_write,) = loc.shape
+
+    nope_dim = k_nope.shape[1]
+    rope_dim = k_rope.shape[1]
+    scale_dim = scale_k_nope.shape[1]
+
+    buf_fp8 = buf.view(fp8_dtype).flatten()
+    buf_bf16 = buf.view(torch.bfloat16).flatten()
+    buf_scale = buf.view(torch.uint8).flatten()
+
+    loc_page_index = loc // page_size
+    loc_token_offset_in_page = loc % page_size
+
+    s_offset_nbytes_in_page = page_size * (nope_dim + rope_dim * 2)
+
+    nope_offset = loc_page_index * buf_numel_per_page + loc_token_offset_in_page * (
+        nope_dim + rope_dim * 2
+    )
+
+    rope_offset = (
+        loc_page_index * buf_numel_per_page // 2
+        + (loc_token_offset_in_page * (nope_dim + rope_dim * 2) + nope_dim) // 2
+    )
+
+    s_offset = (
+        loc_page_index * buf_numel_per_page
+        + s_offset_nbytes_in_page
+        + loc_token_offset_in_page * (scale_dim + 1)
+    )
+
+    for i in range(num_tokens_to_write):
+        buf_fp8[nope_offset[i] : nope_offset[i] + nope_dim] = k_nope[i]
+        buf_bf16[rope_offset[i] : rope_offset[i] + rope_dim] = k_rope[i]
+        buf_scale[s_offset[i] : s_offset[i] + scale_dim] = scale_k_nope[i]
+
+
+def make_test_data(num_pages, page_size, num_tokens, nope_dim=448, rope_dim=64, scale_dim=7):
+    """Create test data matching the buffer layout."""
+    nope_rope_bytes_per_token = nope_dim + rope_dim * 2
+    s_bytes_per_token = scale_dim + 1
+    buf_numel_per_page = page_size * nope_rope_bytes_per_token + page_size * s_bytes_per_token
+
+    buf = torch.zeros(num_pages, buf_numel_per_page, dtype=torch.uint8)
+
+    # Generate random non-overlapping locations
+    total_slots = num_pages * page_size
+    assert num_tokens <= total_slots
+    perm = torch.randperm(total_slots)[:num_tokens]
+    loc = perm.to(torch.int64)
+
+    k_nope = torch.randint(0, 256, (num_tokens, nope_dim), dtype=torch.uint8).view(fp8_dtype)
+    k_rope = torch.randn(num_tokens, rope_dim, dtype=torch.bfloat16)
+    scale_k_nope = torch.randint(0, 256, (num_tokens, scale_dim), dtype=torch.uint8)
+
+    return buf, loc, k_nope, k_rope, scale_k_nope
+
+
+class TestSetKAndS(CustomTestCase):
+    num_pages_list = [4, 16]
+    page_size_list = [1, 16]
+    num_tokens_list = [1, 7, 32]
+
+    def _test_set_k_and_s(self, num_pages, page_size, num_tokens):
+        max_tokens = num_pages * page_size
+        if num_tokens > max_tokens:
+            num_tokens = max_tokens
+
+        buf, loc, k_nope, k_rope, scale_k_nope = make_test_data(
+            num_pages, page_size, num_tokens
+        )
+
+        # Reference
+        buf_ref = buf.clone()
+        _set_k_and_s_torch(buf_ref, loc, k_nope, k_rope, scale_k_nope, page_size)
+
+        # C++ kernel
+        buf_test = buf.clone()
+        torch.ops.sgl_kernel.set_k_and_s_cpu(
+            buf_test, loc, k_nope, k_rope, scale_k_nope, page_size
+        )
+
+        torch.testing.assert_close(buf_ref, buf_test)
+
+    def test_set_k_and_s(self):
+        for params in itertools.product(
+            self.num_pages_list, self.page_size_list, self.num_tokens_list
+        ):
+            with self.subTest(
+                num_pages=params[0], page_size=params[1], num_tokens=params[2]
+            ):
+                self._test_set_k_and_s(*params)
+
+    def test_set_k_and_s_int32_loc(self):
+        """Test with int32 loc tensor."""
+        buf, loc, k_nope, k_rope, scale_k_nope = make_test_data(8, 16, 20)
+        loc_i32 = loc.to(torch.int32)
+
+        buf_ref = buf.clone()
+        _set_k_and_s_torch(buf_ref, loc, k_nope, k_rope, scale_k_nope, 16)
+
+        buf_test = buf.clone()
+        torch.ops.sgl_kernel.set_k_and_s_cpu(
+            buf_test, loc_i32, k_nope, k_rope, scale_k_nope, 16
+        )
+
+        torch.testing.assert_close(buf_ref, buf_test)
+
+    def test_set_k_and_s_large(self):
+        """Larger stress test."""
+        num_pages, page_size, num_tokens = 64, 16, 512
+        buf, loc, k_nope, k_rope, scale_k_nope = make_test_data(
+            num_pages, page_size, num_tokens
+        )
+
+        buf_ref = buf.clone()
+        _set_k_and_s_torch(buf_ref, loc, k_nope, k_rope, scale_k_nope, page_size)
+
+        buf_test = buf.clone()
+        torch.ops.sgl_kernel.set_k_and_s_cpu(
+            buf_test, loc, k_nope, k_rope, scale_k_nope, page_size
+        )
+
+        torch.testing.assert_close(buf_ref, buf_test)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/cpu/test_store_cache.py
+++ b/test/srt/cpu/test_store_cache.py
@@ -138,5 +138,115 @@ class TestSetKAndS(CustomTestCase):
         torch.testing.assert_close(buf_ref, buf_test)
 
 
+# ===========================================================================
+# Reference for quant_to_nope_fp8_rope_bf16_pack
+# ===========================================================================
+
+def _cast_scale_inv_to_ue8m0(scales_inv, out_dtype=torch.float32):
+    return torch.pow(2, torch.clamp_min(scales_inv, 1e-4).log2().ceil()).to(out_dtype)
+
+
+def quant_to_nope_fp8_rope_bf16_pack_ref(k_bf16):
+    """Reference implementation from quant_k_cache_v4.py."""
+    assert k_bf16.dtype == torch.bfloat16
+    _num_tokens, hidden_dim = k_bf16.shape
+    assert hidden_dim == 512
+    dim_nope = 448
+    dim_rope = 64
+
+    k_nope_bf16, k_rope_bf16 = k_bf16.split([dim_nope, dim_rope], dim=-1)
+
+    tile_size = 64
+    num_tiles = dim_nope // tile_size
+
+    x = k_nope_bf16.contiguous().view(-1, num_tiles, tile_size)
+    scale = x.abs().amax(dim=-1).float() / 448.0
+    scale_pow2_fp32 = _cast_scale_inv_to_ue8m0(scale, out_dtype=torch.float32)
+    scale_k_nope_ue8m0 = scale_pow2_fp32.to(torch.float8_e8m0fnu)
+    k_nope_fp8 = (x.float() / scale_pow2_fp32.unsqueeze(-1)).to(fp8_dtype)
+    k_nope_fp8 = k_nope_fp8.view(-1, tile_size * num_tiles)
+    scale_k_nope_ue8m0 = scale_k_nope_ue8m0.view(torch.uint8)
+
+    return k_nope_fp8, k_rope_bf16.contiguous(), scale_k_nope_ue8m0
+
+
+class TestQuantToNopeFp8RopeBf16Pack(CustomTestCase):
+    num_tokens_list = [1, 7, 32, 128, 512]
+
+    def _test_quant(self, num_tokens):
+        k_bf16 = torch.randn(num_tokens, 512, dtype=torch.bfloat16)
+
+        ref_nope, ref_rope, ref_scale = quant_to_nope_fp8_rope_bf16_pack_ref(k_bf16)
+        cpp_nope, cpp_rope, cpp_scale = (
+            torch.ops.sgl_kernel.quant_to_nope_fp8_rope_bf16_pack_cpu(k_bf16)
+        )
+
+        torch.testing.assert_close(ref_rope, cpp_rope)
+        torch.testing.assert_close(ref_scale, cpp_scale)
+        torch.testing.assert_close(
+            ref_nope.view(torch.uint8), cpp_nope.view(torch.uint8)
+        )
+
+    def test_quant_various_sizes(self):
+        for num_tokens in self.num_tokens_list:
+            with self.subTest(num_tokens=num_tokens):
+                self._test_quant(num_tokens)
+
+    def test_quant_small_values(self):
+        """Test with very small values that exercise the EPS clamp."""
+        k_bf16 = torch.randn(16, 512, dtype=torch.bfloat16) * 1e-6
+        ref_nope, ref_rope, ref_scale = quant_to_nope_fp8_rope_bf16_pack_ref(k_bf16)
+        cpp_nope, cpp_rope, cpp_scale = (
+            torch.ops.sgl_kernel.quant_to_nope_fp8_rope_bf16_pack_cpu(k_bf16)
+        )
+        torch.testing.assert_close(ref_rope, cpp_rope)
+        torch.testing.assert_close(ref_scale, cpp_scale)
+        torch.testing.assert_close(
+            ref_nope.view(torch.uint8), cpp_nope.view(torch.uint8)
+        )
+
+    def test_quant_large_values(self):
+        """Test with large values."""
+        k_bf16 = torch.randn(16, 512, dtype=torch.bfloat16) * 100.0
+        ref_nope, ref_rope, ref_scale = quant_to_nope_fp8_rope_bf16_pack_ref(k_bf16)
+        cpp_nope, cpp_rope, cpp_scale = (
+            torch.ops.sgl_kernel.quant_to_nope_fp8_rope_bf16_pack_cpu(k_bf16)
+        )
+        torch.testing.assert_close(ref_rope, cpp_rope)
+        torch.testing.assert_close(ref_scale, cpp_scale)
+        torch.testing.assert_close(
+            ref_nope.view(torch.uint8), cpp_nope.view(torch.uint8)
+        )
+
+    def test_quant_zeros(self):
+        """Test with zero input."""
+        k_bf16 = torch.zeros(8, 512, dtype=torch.bfloat16)
+        ref_nope, ref_rope, ref_scale = quant_to_nope_fp8_rope_bf16_pack_ref(k_bf16)
+        cpp_nope, cpp_rope, cpp_scale = (
+            torch.ops.sgl_kernel.quant_to_nope_fp8_rope_bf16_pack_cpu(k_bf16)
+        )
+        torch.testing.assert_close(ref_rope, cpp_rope)
+        torch.testing.assert_close(ref_scale, cpp_scale)
+        torch.testing.assert_close(
+            ref_nope.view(torch.uint8), cpp_nope.view(torch.uint8)
+        )
+
+    def test_output_shapes_and_dtypes(self):
+        """Verify output shapes and dtypes."""
+        num_tokens = 16
+        k_bf16 = torch.randn(num_tokens, 512, dtype=torch.bfloat16)
+        cpp_nope, cpp_rope, cpp_scale = (
+            torch.ops.sgl_kernel.quant_to_nope_fp8_rope_bf16_pack_cpu(k_bf16)
+        )
+
+        self.assertEqual(cpp_nope.shape, (num_tokens, 448))
+        self.assertEqual(cpp_rope.shape, (num_tokens, 64))
+        self.assertEqual(cpp_scale.shape, (num_tokens, 7))
+
+        self.assertEqual(cpp_nope.dtype, fp8_dtype)
+        self.assertEqual(cpp_rope.dtype, torch.bfloat16)
+        self.assertEqual(cpp_scale.dtype, torch.uint8)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Performance:
command: `SGLANG_OPT_BF16_FP32_GEMM_ALGO=cpu_amx SGLANG_OPT_USE_TILELANG_MHC_SPLIT_SINKHORN=false SGLANG_OPT_USE_TILELANG_SWA_PREPARE=false SGLANG_OPT_USE_JIT_KERNEL_FUSED_TOPK=false SGLANG_OPT_USE_FUSED_HASH_TOPK=false SGLANG_HACK_FLASHMLA_BACKEND=cpu_amx SGLANG_OPT_DEEPGEMM_HC_PRENORM=false SGLANG_OPT_USE_TILELANG_MHC_PRE=false SGLANG_OPT_USE_TILELANG_MHC_POST=false SGLANG_TOPK_TRANSFORM_512_TORCH=1 SGLANG_FP8_PAGED_MQA_LOGITS_TORCH=1 SGLANG_DSV4_FP4_EXPERTS=true SGLANG_OPT_USE_OVERLAP_STORE_CACHE=false SGLANG_OPT_USE_FUSED_STORE_CACHE=false SGLANG_OPT_USE_OLD_COMPRESSOR=true SGLANG_OPT_USE_FUSED_COMPRESS=false SGLANG_OPT_USE_FUSED_PAGED_COMPRESS=false SGLANG_OPT_DPSK_V4_RADIX=false SGLANG_CPU_OMP_THREADS_BIND="96-127|128-159" python -m sglang.bench_one_batch --model-path /localdisk/models/hub/ds-v4-flash/ --trust-remote-code --tp 2 --attention-backend compressed --page-size 256 --disable-shared-experts-fusion --disable-cuda-graph --tool-call-parser deepseekv4 --reasoning-parser deepseek-v4 --input-len 256 --output-len 256 --batch-size 1 --profile`

Before:
Prefill:
<img width="2498" height="109" alt="image" src="https://github.com/user-attachments/assets/4078ec57-c260-4f44-90a9-0c2639b9a18e" />
<img width="2175" height="139" alt="image" src="https://github.com/user-attachments/assets/e0126e1e-2726-4335-a3c2-26dd28d2113b" />
<img width="2405" height="144" alt="image" src="https://github.com/user-attachments/assets/0b361f63-60cd-4e6c-82dc-db51209dc262" />
Decode:
<img width="2440" height="112" alt="image" src="https://github.com/user-attachments/assets/5dcea362-93f8-470d-ac6f-3e1a38eae3b4" />
<img width="2374" height="127" alt="image" src="https://github.com/user-attachments/assets/121ae41e-5f98-4446-bf98-b4740572fee0" />
<img width="2379" height="139" alt="image" src="https://github.com/user-attachments/assets/c89a0e70-cc44-4f04-9bb8-584820065e5e" />

After:
Prefill:
<img width="1680" height="358" alt="image" src="https://github.com/user-attachments/assets/960586bc-247a-41a3-bf2e-640fc773ae97" />

Decode:
<img width="1635" height="844" alt="image" src="https://github.com/user-attachments/assets/9e10bc08-27a8-48d9-bfbd-f42dbc3d8382" />



Accuracy:
Command: `SGLANG_OPT_BF16_FP32_GEMM_ALGO=cpu_amx SGLANG_OPT_USE_TILELANG_MHC_SPLIT_SINKHORN=false SGLANG_OPT_USE_TILELANG_SWA_PREPARE=false SGLANG_OPT_USE_JIT_KERNEL_FUSED_TOPK=false SGLANG_OPT_USE_FUSED_HASH_TOPK=false SGLANG_HACK_FLASHMLA_BACKEND=cpu_amx SGLANG_OPT_DEEPGEMM_HC_PRENORM=false SGLANG_OPT_USE_TILELANG_MHC_PRE=false SGLANG_OPT_USE_TILELANG_MHC_POST=false SGLANG_TOPK_TRANSFORM_512_TORCH=1 SGLANG_FP8_PAGED_MQA_LOGITS_TORCH=1 SGLANG_DSV4_FP4_EXPERTS=true SGLANG_OPT_USE_OVERLAP_STORE_CACHE=false SGLANG_OPT_USE_FUSED_STORE_CACHE=false SGLANG_OPT_USE_OLD_COMPRESSOR=true SGLANG_OPT_USE_FUSED_COMPRESS=false SGLANG_OPT_USE_FUSED_PAGED_COMPRESS=false SGLANG_OPT_DPSK_V4_RADIX=false SGLANG_CPU_OMP_THREADS_BIND="96-127|128-159" python -m sglang.launch_server --model-path /localdisk/models/hub/ds-v4-flash/ --trust-remote-code --tp 2 --attention-backend compressed --page-size 256 --disable-shared-experts-fusion --disable-cuda-graph --tool-call-parser deepseekv4 --reasoning-parser deepseek-v4`

Result:
<img width="2430" height="165" alt="image" src="https://github.com/user-attachments/assets/c1db5a09-3032-4534-9716-fd7a11b8d19d" />




