### PR TITLE
Add kernel act_quant_cpu and fused_scale_cpu

### DIFF
--- a/python/sglang/srt/layers/attention/compressed/compressor.py
+++ b/python/sglang/srt/layers/attention/compressed/compressor.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, List, Literal, NamedTuple, Optional, Union
+from typing import TYPE_CHECKING, List, Literal, NamedTuple, Optional, Tuple, Union
 
 import torch
 
@@ -20,12 +20,16 @@ from sglang.srt.layers.attention.nsa.triton_kernel import act_quant
 from sglang.srt.layers.attention.nsa.utils import (
     assert_tensor_identical_across_cp_ranks,
 )
+from sglang.srt.utils import cpu_has_amx_support, is_cpu
 
 if TYPE_CHECKING:
     from sglang.srt.layers.attention.compressed.metadata import DeepseekV4Metadata
     from sglang.srt.mem_cache.deepseekv4_memory_pool import DeepSeekV4TokenToKVPool
     from sglang.srt.model_executor.forward_batch_info import ForwardBatch
     from sglang.srt.models.deepseek_v4 import Compressor, DeepseekRefRMSNorm
+
+
+_is_cpu_amx_available = is_cpu() and cpu_has_amx_support()
 
 
 def act_quant_pytorch(
@@ -94,7 +98,13 @@ def act_quant_pytorch(
     return y, s
 
 
-act_quant = act_quant_pytorch
+def act_quant_cpu(
+    x: torch.Tensor, block_size: int = 128, scale_fmt: Optional[str] = None
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    return torch.ops.sgl_kernel.act_quant_cpu(x, block_size, scale_fmt)
+
+
+act_quant = act_quant_cpu if _is_cpu_amx_available else act_quant_pytorch
 
 class FusedCompressMetadata(NamedTuple):
     write_loc: torch.Tensor

--- a/python/sglang/srt/layers/attention/compressed/indexer.py
+++ b/python/sglang/srt/layers/attention/compressed/indexer.py
@@ -95,7 +95,13 @@ def act_quant_pytorch(
     return y, s
 
 
-act_quant = act_quant_pytorch
+def act_quant_cpu(
+    x: torch.Tensor, block_size: int = 128, scale_fmt: Optional[str] = None
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    return torch.ops.sgl_kernel.act_quant_cpu(x, block_size, scale_fmt)
+
+
+act_quant = act_quant_cpu if _is_cpu_amx_available else act_quant_pytorch
 
 if is_hip():
     FP8_DTYPE = torch.float8_e4m3fnuz

--- a/python/sglang/srt/layers/attention/compressed/indexer.py
+++ b/python/sglang/srt/layers/attention/compressed/indexer.py
@@ -352,6 +352,13 @@ def fused_scale_torch(
     return out
 
 
+def fused_scale_cpu(
+    weight: torch.Tensor,
+    out_scale: float,
+    q_scale: torch.Tensor,
+) -> torch.Tensor:
+    return torch.ops.sgl_kernel.fused_scale_cpu(weight, out_scale, q_scale)
+
 class C4IndexerBackend:
     def __init__(self):
         super().__init__()
@@ -423,7 +430,10 @@ class C4IndexerBackend:
         q = c4_indexer.compute_q(q_lora, positions=positions)
         q_fp8, q_scale = act_quant(q)
         weights = c4_indexer.compute_weights(x, skip_scale=True)
-        weights = fused_scale_torch(weights, c4_indexer.weight_scale, q_scale)
+        if _is_cpu_amx_available:
+            weights = fused_scale_cpu(weights, c4_indexer.weight_scale, q_scale)
+        else:
+            weights = fused_scale_torch(weights, c4_indexer.weight_scale, q_scale)
         self.forward_indexer_compressor(
             x=x,
             forward_batch=forward_batch,

--- a/sgl-kernel/csrc/cpu/act_quant.cpp
+++ b/sgl-kernel/csrc/cpu/act_quant.cpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "common.h"
+#include "vec.h"
 
 namespace {
 
@@ -17,21 +18,18 @@ constexpr float kFP8Max = 448.0f;
 constexpr float kFP8Min = -448.0f;
 constexpr float kMinScaleAmax = 1.0e-4f;
 
-template <typename scalar_t, bool round_scale>
+template <bool round_scale, typename scalar_t>
 void act_quant_cpu_impl(
-    at::Tensor& y,
-    at::Tensor& scale,
-    const at::Tensor& x,
+    at::Float8_e4m3fn* __restrict__ y_ptr,
+    float* __restrict__ scale_ptr,
+    const scalar_t* __restrict__ x_ptr,
     int64_t block_size,
     int64_t M,
     int64_t N,
     int64_t num_groups) {
-  const scalar_t* __restrict__ x_ptr = x.const_data_ptr<scalar_t>();
-  auto* __restrict__ y_ptr = y.mutable_data_ptr<at::Float8_e4m3fn>();
-  float* __restrict__ scale_ptr = scale.mutable_data_ptr<float>();
 
   const int64_t total_blocks = M * num_groups;
-  at::parallel_for(0, total_blocks, GRAIN_SIZE, [&](int64_t begin, int64_t end) {
+  at::parallel_for(0, total_blocks, 0, [&](int64_t begin, int64_t end) {
     int64_t m = 0;
     int64_t group = 0;
     data_index_init(begin, m, M, group, num_groups);
@@ -65,12 +63,99 @@ void act_quant_cpu_impl(
   });
 }
 
+#if defined(CPU_CAPABILITY_AVX512)
+
+template <bool round_scale>
+void act_quant_cpu_impl(
+    at::Float8_e4m3fn* __restrict__ y_ptr,
+    float* __restrict__ scale_ptr,
+    const at::BFloat16* __restrict__ x_ptr,
+    int64_t block_size,
+    int64_t M,
+    int64_t N,
+    int64_t num_groups) {
+  const int64_t total_blocks = M * num_groups;
+  at::parallel_for(0, total_blocks, 0, [&](int64_t begin, int64_t end) {
+    const __m512 signBit = _mm512_set1_ps(-0.0f);
+    const __m512 vfp8_min = _mm512_set1_ps(kFP8Min);
+    const __m512 vfp8_max = _mm512_set1_ps(kFP8Max);
+
+    int64_t m = 0;
+    int64_t group = 0;
+    data_index_init(begin, m, M, group, num_groups);
+
+    for (int64_t offset = begin; offset < end; ++offset) {
+      const int64_t base = m * N + group * block_size;
+      const at::BFloat16* __restrict__ x_block = x_ptr + base;
+      auto* __restrict__ y_block = y_ptr + base;
+
+      // Phase 1: vectorized absolute max reduction
+      __m512 vamax0 = _mm512_setzero_ps();
+      __m512 vamax1 = _mm512_setzero_ps();
+      int64_t d = 0;
+      for (; d + 32 <= block_size; d += 32) {
+        __m512i raw = _mm512_loadu_si512(reinterpret_cast<const void*>(x_block + d));
+        __m512 v0 = CVT_BF16_TO_FP32(_mm512_extracti32x8_epi32(raw, 0));
+        __m512 v1 = CVT_BF16_TO_FP32(_mm512_extracti32x8_epi32(raw, 1));
+        vamax0 = _mm512_max_ps(vamax0, _mm512_andnot_ps(signBit, v0));
+        vamax1 = _mm512_max_ps(vamax1, _mm512_andnot_ps(signBit, v1));
+      }
+      float amax = _mm512_reduce_max_ps(_mm512_max_ps(vamax0, vamax1));
+      for (; d < block_size; ++d) {
+        amax = std::max(amax, std::abs(static_cast<float>(x_block[d])));
+      }
+      amax = std::max(amax, kMinScaleAmax);
+
+      // Phase 2: compute scale
+      float scale_value;
+      if constexpr (round_scale) {
+        scale_value = std::exp2(std::ceil(std::log2(amax / kFP8Max)));
+      } else {
+        scale_value = amax / kFP8Max;
+      }
+      scale_ptr[offset] = scale_value;
+
+      // Phase 3: vectorized scale + scalar FP8 conversion
+      const float inv_scale = 1.0f / scale_value;
+      const __m512 vinv_scale = _mm512_set1_ps(inv_scale);
+      const __m512 vfp8_min_local = vfp8_min;
+      const __m512 vfp8_max_local = vfp8_max;
+      d = 0;
+      // Use vectorized scaling, then scalar FP8 cast to match reference exactly
+      alignas(64) float scaled_buf[32];
+      for (; d + 32 <= block_size; d += 32) {
+        __m512i raw = _mm512_loadu_si512(reinterpret_cast<const void*>(x_block + d));
+        __m512 v0 = CVT_BF16_TO_FP32(_mm512_extracti32x8_epi32(raw, 0));
+        __m512 v1 = CVT_BF16_TO_FP32(_mm512_extracti32x8_epi32(raw, 1));
+
+        v0 = _mm512_min_ps(_mm512_max_ps(_mm512_mul_ps(v0, vinv_scale), vfp8_min_local), vfp8_max_local);
+        v1 = _mm512_min_ps(_mm512_max_ps(_mm512_mul_ps(v1, vinv_scale), vfp8_min_local), vfp8_max_local);
+
+        _mm512_store_ps(scaled_buf, v0);
+        _mm512_store_ps(scaled_buf + 16, v1);
+
+        for (int64_t i = 0; i < 32; ++i) {
+          y_block[d + i] = at::Float8_e4m3fn(scaled_buf[i]);
+        }
+      }
+      // Scalar remainder
+      for (; d < block_size; ++d) {
+        float value = static_cast<float>(x_block[d]) * inv_scale;
+        value = std::min(std::max(value, kFP8Min), kFP8Max);
+        y_block[d] = at::Float8_e4m3fn(value);
+      }
+
+      data_index_step(m, M, group, num_groups);
+    }
+  });
+}
+
+#endif  // CPU_CAPABILITY_AVX512
+
 }  // namespace
 
 std::tuple<at::Tensor, at::Tensor> act_quant_cpu(
     at::Tensor& x, int64_t block_size, const std::optional<std::string>& scale_fmt) {
-  RECORD_FUNCTION("sgl-kernel::act_quant_cpu", std::vector<c10::IValue>({x}));
-
   CHECK_INPUT(x);
   TORCH_CHECK(x.dim() >= 1, "x must have at least 1 dimension");
   TORCH_CHECK(block_size > 0, "block_size must be positive");
@@ -88,11 +173,11 @@ std::tuple<at::Tensor, at::Tensor> act_quant_cpu(
   at::Tensor scale = at::empty(scale_sizes, x.options().dtype(at::kFloat));
 
   const bool round_scale = scale_fmt.has_value();
-  AT_DISPATCH_FLOATING_TYPES_AND2(at::kHalf, at::kBFloat16, x.scalar_type(), "act_quant_cpu", [&] {
+  CPU_DISPATCH_FLOATING_TYPES(x.scalar_type(), "act_quant_cpu", [&] {
     if (round_scale) {
-      act_quant_cpu_impl<scalar_t, true>(y, scale, x, block_size, M, N, num_groups);
+      act_quant_cpu_impl<true>(y.data_ptr<at::Float8_e4m3fn>(), scale.data_ptr<float>(), x.data_ptr<scalar_t>(), block_size, M, N, num_groups);
     } else {
-      act_quant_cpu_impl<scalar_t, false>(y, scale, x, block_size, M, N, num_groups);
+      act_quant_cpu_impl<false>(y.data_ptr<at::Float8_e4m3fn>(), scale.data_ptr<float>(), x.data_ptr<scalar_t>(), block_size, M, N, num_groups);
     }
   });
 

--- a/sgl-kernel/csrc/cpu/act_quant.cpp
+++ b/sgl-kernel/csrc/cpu/act_quant.cpp
@@ -1,0 +1,100 @@
+#include <ATen/ATen.h>
+#include <ATen/Parallel.h>
+#include <ATen/record_function.h>
+#include <c10/util/Float8_e4m3fn.h>
+#include <torch/all.h>
+
+#include <cmath>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "common.h"
+
+namespace {
+
+constexpr float kFP8Max = 448.0f;
+constexpr float kFP8Min = -448.0f;
+constexpr float kMinScaleAmax = 1.0e-4f;
+
+template <typename scalar_t, bool round_scale>
+void act_quant_cpu_impl(
+    at::Tensor& y,
+    at::Tensor& scale,
+    const at::Tensor& x,
+    int64_t block_size,
+    int64_t M,
+    int64_t N,
+    int64_t num_groups) {
+  const scalar_t* __restrict__ x_ptr = x.const_data_ptr<scalar_t>();
+  auto* __restrict__ y_ptr = y.mutable_data_ptr<at::Float8_e4m3fn>();
+  float* __restrict__ scale_ptr = scale.mutable_data_ptr<float>();
+
+  const int64_t total_blocks = M * num_groups;
+  at::parallel_for(0, total_blocks, GRAIN_SIZE, [&](int64_t begin, int64_t end) {
+    int64_t m = 0;
+    int64_t group = 0;
+    data_index_init(begin, m, M, group, num_groups);
+
+    for (int64_t offset = begin; offset < end; ++offset) {
+      const int64_t base = m * N + group * block_size;
+
+      float amax = 0.0f;
+      for (int64_t d = 0; d < block_size; ++d) {
+        amax = std::max(amax, std::abs(static_cast<float>(x_ptr[base + d])));
+      }
+      amax = std::max(amax, kMinScaleAmax);
+
+      float scale_value;
+      if constexpr (round_scale) {
+        scale_value = std::exp2(std::ceil(std::log2(amax / kFP8Max)));
+      } else {
+        scale_value = amax / kFP8Max;
+      }
+      scale_ptr[offset] = scale_value;
+
+      const float inv_scale = 1.0f / scale_value;
+      for (int64_t d = 0; d < block_size; ++d) {
+        float value = static_cast<float>(x_ptr[base + d]) * inv_scale;
+        value = std::min(std::max(value, kFP8Min), kFP8Max);
+        y_ptr[base + d] = at::Float8_e4m3fn(value);
+      }
+
+      data_index_step(m, M, group, num_groups);
+    }
+  });
+}
+
+}  // namespace
+
+std::tuple<at::Tensor, at::Tensor> act_quant_cpu(
+    at::Tensor& x, int64_t block_size, const std::optional<std::string>& scale_fmt) {
+  RECORD_FUNCTION("sgl-kernel::act_quant_cpu", std::vector<c10::IValue>({x}));
+
+  CHECK_INPUT(x);
+  TORCH_CHECK(x.dim() >= 1, "x must have at least 1 dimension");
+  TORCH_CHECK(block_size > 0, "block_size must be positive");
+
+  const int64_t N = x.size(-1);
+  TORCH_CHECK(N % block_size == 0, "Last dimension size must be divisible by block_size");
+
+  const int64_t M = x.numel() / N;
+  const int64_t num_groups = N / block_size;
+
+  at::Tensor y = at::empty_like(x, x.options().dtype(at::kFloat8_e4m3fn));
+
+  std::vector<int64_t> scale_sizes = x.sizes().vec();
+  scale_sizes.back() = num_groups;
+  at::Tensor scale = at::empty(scale_sizes, x.options().dtype(at::kFloat));
+
+  const bool round_scale = scale_fmt.has_value();
+  AT_DISPATCH_FLOATING_TYPES_AND2(at::kHalf, at::kBFloat16, x.scalar_type(), "act_quant_cpu", [&] {
+    if (round_scale) {
+      act_quant_cpu_impl<scalar_t, true>(y, scale, x, block_size, M, N, num_groups);
+    } else {
+      act_quant_cpu_impl<scalar_t, false>(y, scale, x, block_size, M, N, num_groups);
+    }
+  });
+
+  return {y, scale};
+}

--- a/sgl-kernel/csrc/cpu/fused_scale.cpp
+++ b/sgl-kernel/csrc/cpu/fused_scale.cpp
@@ -1,0 +1,57 @@
+#include <ATen/ATen.h>
+#include <ATen/Parallel.h>
+#include <ATen/record_function.h>
+#include <torch/all.h>
+
+#include <vector>
+
+#include "common.h"
+
+namespace {
+
+template <typename out_t, typename weight_t, typename scale_t>
+void fused_scale_cpu_impl(
+    at::Tensor& out,
+    const at::Tensor& weight,
+    const at::Tensor& q_scale,
+    double out_scale,
+    int64_t numel) {
+  const weight_t* __restrict__ weight_ptr = weight.const_data_ptr<weight_t>();
+  const scale_t* __restrict__ q_scale_ptr = q_scale.const_data_ptr<scale_t>();
+  out_t* __restrict__ out_ptr = out.mutable_data_ptr<out_t>();
+  const float out_scale_f = static_cast<float>(out_scale);
+
+  at::parallel_for(0, numel, GRAIN_SIZE, [&](int64_t begin, int64_t end) {
+    for (int64_t i = begin; i < end; ++i) {
+      const float value = static_cast<float>(weight_ptr[i]) * out_scale_f * static_cast<float>(q_scale_ptr[i]);
+      out_ptr[i] = static_cast<out_t>(value);
+    }
+  });
+}
+
+}  // namespace
+
+at::Tensor fused_scale_cpu(at::Tensor& weight, double out_scale, at::Tensor& q_scale) {
+  RECORD_FUNCTION("sgl-kernel::fused_scale_cpu", std::vector<c10::IValue>({weight, q_scale}));
+
+  CHECK_INPUT(weight);
+  CHECK_INPUT(q_scale);
+  CHECK_DIM(2, weight);
+  TORCH_CHECK(q_scale.numel() == weight.numel(), "q_scale must have the same number of elements as weight");
+  TORCH_CHECK(
+      weight.scalar_type() == at::kFloat || weight.scalar_type() == at::kHalf || weight.scalar_type() == at::kBFloat16,
+      "weight must be float32, float16, or bfloat16");
+  TORCH_CHECK(q_scale.scalar_type() == at::kFloat, "q_scale must be float32");
+
+  const int64_t B = weight.size(0);
+  const int64_t H = weight.size(1);
+  const int64_t numel = B * H;
+  at::Tensor out = at::empty({B, H, 1}, weight.options().dtype(at::kFloat));
+
+  AT_DISPATCH_FLOATING_TYPES_AND2(
+      at::kHalf, at::kBFloat16, weight.scalar_type(), "fused_scale_cpu_weight", [&] {
+        fused_scale_cpu_impl<float, scalar_t, float>(out, weight, q_scale, out_scale, numel);
+      });
+
+  return out;
+}

--- a/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
+++ b/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
@@ -187,6 +187,8 @@ at::Tensor convert_scale_packed(at::Tensor& scale);
 
 // quant
 std::tuple<at::Tensor, at::Tensor> per_token_quant_int8_cpu(at::Tensor& A);
+std::tuple<at::Tensor, at::Tensor> act_quant_cpu(
+    at::Tensor& x, int64_t block_size, const std::optional<std::string>& scale_fmt);
 
 // gemm
 at::Tensor weight_packed_linear(
@@ -561,6 +563,8 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   // quant
   m.def("per_token_quant_int8_cpu(Tensor A) -> (Tensor, Tensor)");
   m.impl("per_token_quant_int8_cpu", torch::kCPU, &per_token_quant_int8_cpu);
+    m.def("act_quant_cpu(Tensor x, int block_size=128, str? scale_fmt=None) -> (Tensor, Tensor)");
+    m.impl("act_quant_cpu", torch::kCPU, &act_quant_cpu);
 
   // gemm
   m.def(

--- a/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
+++ b/sgl-kernel/csrc/cpu/torch_extension_cpu.cpp
@@ -189,6 +189,7 @@ at::Tensor convert_scale_packed(at::Tensor& scale);
 std::tuple<at::Tensor, at::Tensor> per_token_quant_int8_cpu(at::Tensor& A);
 std::tuple<at::Tensor, at::Tensor> act_quant_cpu(
     at::Tensor& x, int64_t block_size, const std::optional<std::string>& scale_fmt);
+at::Tensor fused_scale_cpu(at::Tensor& weight, double out_scale, at::Tensor& q_scale);
 
 // gemm
 at::Tensor weight_packed_linear(
@@ -565,6 +566,8 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   m.impl("per_token_quant_int8_cpu", torch::kCPU, &per_token_quant_int8_cpu);
     m.def("act_quant_cpu(Tensor x, int block_size=128, str? scale_fmt=None) -> (Tensor, Tensor)");
     m.impl("act_quant_cpu", torch::kCPU, &act_quant_cpu);
+    m.def("fused_scale_cpu(Tensor weight, float out_scale, Tensor q_scale) -> Tensor");
+    m.impl("fused_scale_cpu", torch::kCPU, &fused_scale_cpu);
 
   // gemm
   m.def(

--- a/test/srt/cpu/test_act_quant_cpu.py
+++ b/test/srt/cpu/test_act_quant_cpu.py
@@ -1,0 +1,54 @@
+import itertools
+import unittest
+
+import torch
+
+from sglang.srt.layers.attention.compressed.compressor import act_quant_pytorch
+
+
+def _assert_fp8_equal(ref: torch.Tensor, out: torch.Tensor) -> None:
+    assert ref.dtype == torch.float8_e4m3fn
+    assert out.dtype == torch.float8_e4m3fn
+    torch.testing.assert_close(ref.view(torch.uint8), out.view(torch.uint8), atol=0, rtol=0)
+
+
+class TestActQuantCPU(unittest.TestCase):
+    shapes = [(1, 128), (3, 256), (2, 3, 128), (2, 2, 384)]
+    dtypes = [torch.float32, torch.bfloat16, torch.float16]
+    scale_fmts = [None, "power2"]
+
+    def _run_case(self, shape, dtype, scale_fmt):
+        torch.manual_seed(1234)
+        x = (torch.randn(shape, dtype=torch.float32) * 3.0).to(dtype).contiguous()
+
+        ref_y, ref_scale = act_quant_pytorch(x, block_size=128, scale_fmt=scale_fmt)
+        out_y, out_scale = torch.ops.sgl_kernel.act_quant_cpu(
+            x, 128, scale_fmt
+        )
+
+        _assert_fp8_equal(ref_y, out_y)
+        torch.testing.assert_close(ref_scale, out_scale, atol=0, rtol=0)
+
+    def test_act_quant_cpu(self):
+        for shape, dtype, scale_fmt in itertools.product(
+            self.shapes, self.dtypes, self.scale_fmts
+        ):
+            with self.subTest(shape=shape, dtype=dtype, scale_fmt=scale_fmt):
+                self._run_case(shape, dtype, scale_fmt)
+
+    def test_zeros_use_min_scale(self):
+        x = torch.zeros((2, 128), dtype=torch.bfloat16)
+        ref_y, ref_scale = act_quant_pytorch(x, block_size=128)
+        out_y, out_scale = torch.ops.sgl_kernel.act_quant_cpu(x, 128, None)
+
+        _assert_fp8_equal(ref_y, out_y)
+        torch.testing.assert_close(ref_scale, out_scale, atol=0, rtol=0)
+
+    def test_invalid_block_size(self):
+        x = torch.randn((2, 129), dtype=torch.float32)
+        with self.assertRaisesRegex(RuntimeError, "Last dimension size must be divisible"):
+            torch.ops.sgl_kernel.act_quant_cpu(x, 128, None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/cpu/test_fused_scale_cpu.py
+++ b/test/srt/cpu/test_fused_scale_cpu.py
@@ -1,0 +1,44 @@
+import itertools
+import unittest
+
+import torch
+
+from sglang.srt.layers.attention.compressed.indexer import fused_scale_torch
+
+
+class TestFusedScaleCPU(unittest.TestCase):
+    shapes = [(1, 1), (2, 8), (3, 128)]
+    weight_dtypes = [torch.float32, torch.bfloat16, torch.float16]
+
+    def _run_case(self, shape, weight_dtype):
+        torch.manual_seed(1234)
+        weight = torch.randn(shape, dtype=torch.float32).to(weight_dtype).contiguous()
+        # act_quant always emits fp32 scales; the kernel pins q_scale to fp32
+        # and always returns fp32 output.
+        q_scale = torch.rand(shape, dtype=torch.float32).contiguous()
+        out_scale = 0.03125
+
+        ref = fused_scale_torch(weight, out_scale, q_scale)
+        out = torch.ops.sgl_kernel.fused_scale_cpu(weight, out_scale, q_scale)
+
+        self.assertEqual(out.shape, (*shape, 1))
+        self.assertEqual(out.dtype, torch.float32)
+        torch.testing.assert_close(out, ref, atol=0, rtol=0)
+
+    def test_fused_scale_cpu(self):
+        for shape, weight_dtype in itertools.product(self.shapes, self.weight_dtypes):
+            with self.subTest(shape=shape, weight_dtype=weight_dtype):
+                self._run_case(shape, weight_dtype)
+
+    def test_q_scale_view_shape(self):
+        weight = torch.randn((2, 4), dtype=torch.bfloat16).contiguous()
+        q_scale = torch.rand((2, 4, 1), dtype=torch.float32).contiguous()
+
+        ref = fused_scale_torch(weight, 0.5, q_scale)
+        out = torch.ops.sgl_kernel.fused_scale_cpu(weight, 0.5, q_scale)
+
+        torch.testing.assert_close(out, ref, atol=0, rtol=0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Before:
<img width="2509" height="616" alt="image" src="https://github.com/user-attachments/assets/3fdda16d-d47d-4d88-bfad-b50f27cec4b5" />


After:
<img width="1582" height="327" alt="image" src="https://github.com/user-attachments/assets/dd98635d-f149-49d6-a7d5-13669f51fdda" />



SGLANG_OPT_BF16_FP32_GEMM_ALGO=cpu_amx SGLANG_OPT_USE_TILELANG_MHC_SPLIT_SINKHORN=false SGLANG_OPT_USE_TILELANG_SWA_PREPARE=false SGLANG_OPT_USE_JIT_KERNEL_FUSED_TOPK=false SGLANG_OPT_USE_FUSED_HASH_TOPK=false SGLANG_HACK_FLASHMLA_BACKEND=cpu_amx SGLANG_OPT_DEEPGEMM_HC_PRENORM=false SGLANG_OPT_USE_TILELANG_MHC_PRE=false SGLANG_OPT_USE_TILELANG_MHC_POST=false  SGLANG_DSV4_FP4_EXPERTS=true SGLANG_OPT_USE_OVERLAP_STORE_CACHE=false SGLANG_OPT_USE_FUSED_STORE_CACHE=false SGLANG_OPT_USE_OLD_COMPRESSOR=true SGLANG_OPT_USE_FUSED_COMPRESS=false SGLANG_OPT_USE_FUSED_PAGED_COMPRESS=false SGLANG_OPT_DPSK_V4_RADIX=false python -m sglang.launch_server --model-path /localdisk/models/hub/ds-v4-flash/ --trust-remote-code --tp 6 --attention-backend compressed --page-size 256 --disable-shared-experts-fusion --disable-cuda-graph --tool-call-parser deepseekv4 --reasoning-parser deepseek-v4

<img width="2458" height="171" alt="image" src="https://github.com/user-attachments/assets/0b4e090e-ee42-4f3b-98c6-a2c9fbedb1f9" />
